### PR TITLE
Feat unifying units [rad, rad/s and mAmps]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
     "rust-analyzer.checkOnSave.allTargets": false,
-    "editor.tabSize": 8,
+    "editor.tabSize": 4,
     "editor.detectIndentation": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
     "rust-analyzer.cargo.target": "thumbv7em-none-eabihf",
-    "rust-analyzer.checkOnSave.allTargets": false
+    "rust-analyzer.checkOnSave.allTargets": false,
+    "editor.tabSize": 8,
+    "editor.detectIndentation": false
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [features]
 #motor specifig config
-default = ["orbita2d", "ec45", "velocity_feedforward","cmd_filter", "gearbox_output" ]
+default = ["orbita2d", "ec45", "velocity_feedforward", "cmd_filter", "gearbox_output" ]
 # default = ["orbita2d", "ec60", "velocity_feedforward","cmd_filter", "axis_output"] #"gearbox_output" ]
 # default = ["orbita3d", "cmd_filter"]
 # default = ["orbita3d"]
@@ -14,6 +14,7 @@ orbita2d = []
 orbita3d = []
 ec60 = []
 ec45=[]
+# use command filter to reduce the jerk of the motor
 cmd_filter = []
 # using velocity feedforward to improve the velocity tracking performance
 # if not included in `defaults` the velocity feedforward is not used

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT OR Apache-2.0"
 
 [features]
 #motor specifig config
-default = ["orbita2d", "ec45", "velocity_feedforward","cmd_filter" ]
-# default = ["orbita2d", "ec60", "velocity_feedforward","cmd_filter" ]
+default = ["orbita2d", "ec45", "velocity_feedforward","cmd_filter", "gearbox_output" ]
+# default = ["orbita2d", "ec60", "velocity_feedforward","cmd_filter", "axis_output"] #"gearbox_output" ]
 # default = ["orbita3d", "cmd_filter"]
 # default = ["orbita3d"]
 orbita2d = []
@@ -15,7 +15,13 @@ orbita3d = []
 ec60 = []
 ec45=[]
 cmd_filter = []
-velocity_feedforward = []
+# using velocity feedforward to improve the velocity tracking performance
+# if not included in `defaults` the velocity feedforward is not used
+velocity_feedforward = [] 
+# deciding which output angle of the motor to control
+# after gearbox, after axis reduction, or directly the motor angle (by not specifying any of the following features in `defaults`)
+gearbox_output = []  # control the motor angle after the gearbox
+axis_output = []  # control the motor angle after the gearbox and axis reduction
 
 [dependencies]
 # rustypot = "0.4.2"

--- a/src/config/current_sense.rs
+++ b/src/config/current_sense.rs
@@ -1,0 +1,70 @@
+pub struct CurrentSensing {
+    
+    // current sensing parameters
+    // Shunt resistor value
+    resistance_shunt: f32, // [Ohms]
+    // gain of the amplifier
+    amp_gain: f32, // [V/V]
+    amp_voltage: f32, // [V]
+
+    // adc offset and scale values - register ADC_I0_SCALE_OFFSET and ADC_I1_SCALE_OFFSET
+    adc_i0_scale_offset: u32,
+    adc_i1_scale_offset: u32,
+}
+
+impl CurrentSensing {
+    #[allow(dead_code)]
+    pub fn wailer_B2() -> Self {
+        let mut return_struct = Self {
+            // current sensing parameters
+            resistance_shunt: 0.003, // [Ohms]
+            amp_gain: 20.0, // [V/V]gain of the amplifier
+            amp_voltage: 5.0, // [V]
+            // middle of the range  and scale 1
+            adc_i0_scale_offset: 0x01000000 | (32768u32),
+            adc_i1_scale_offset: 0x01000000 | (32768u32),
+        };
+        // update the default offset values
+        // this will be automated later on 
+        #[cfg(feature = "ecx22")]
+        return_struct.set_adc_offsets(0x81D3, 0x825B);
+        #[cfg(feature = "ec60")]
+        return_struct.set_adc_offsets(0x81FA,0x826C);
+        #[cfg(feature = "ec45")]
+        return_struct.set_adc_offsets(0x819E, 0x821C);
+
+        return return_struct
+
+    }
+}
+
+impl CurrentSensing {
+    pub fn adc_i0_scale_offset(&self) -> u32 {
+	self.adc_i0_scale_offset
+    }
+    pub fn adc_i1_scale_offset(&self) -> u32 {
+	self.adc_i1_scale_offset
+    }
+    pub fn resistance_shunt(&self) -> f32 {
+        self.resistance_shunt
+    }
+    pub fn amp_gain(&self) -> f32 {
+        self.amp_gain
+    }
+    pub fn amp_voltage(&self) -> f32 {
+        self.amp_voltage
+    }
+
+    pub fn set_adc_offsets(&mut self, i0: u32, i1: u32) {
+        self.adc_i0_scale_offset = 0x01000000 | i0;
+        self.adc_i1_scale_offset = 0x01000000 | i1;
+    }
+    // transforming the raw adc counts to milliamps
+    pub fn adc_to_mAmps(&self, adc_raw: f32, adc_resolution:f32) -> f32{
+        adc_raw * ( self.amp_voltage / adc_resolution)/(self.amp_gain*self.resistance_shunt) * 1000.0 // amp_volt/adc_res -> counts to volts, 1/shunt*gain -> volts to amps
+    }
+    // transforming milliamps to raw adc counts
+    pub fn mAmps_tp_adc(&self, amps: f32, adc_resolution:f32) -> f32{
+        amps / 1000.0 * (self.amp_gain*self.resistance_shunt) / (self.amp_voltage / adc_resolution) // shunt*gain -> amps to volts, adc_res/amp_volt -> volts to adc counts 
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -72,3 +72,5 @@ pub struct ActuatorConfig {
 
 mod motor;
 pub use motor::BrushlessMotor;
+mod current_sense;
+pub use current_sense::CurrentSensing;

--- a/src/config/motor.rs
+++ b/src/config/motor.rs
@@ -1,14 +1,21 @@
 pub struct BrushlessMotor {
+    // 0x00030004: 3-phase brushless motor, 4 pole pairs - register MOTOR_TYPE_N_POLE_PAIRS
     motor_type_n_pole_pairs: u32,
+    // adc offset and scale values - register ADC_I0_SCALE_OFFSET and ADC_I1_SCALE_OFFSET
     adc_i0_scale_offset: u32,
     adc_i1_scale_offset: u32,
 
+    // pid flux and torque P and I gains - register PID_FLUX_P_FLUX_I and PID_TORQUE_P_TORQUE_I
     pid_flux_p_flux_i: u32,
     pid_torque_p_torque_i: u32,
+    // pid velocity and position P and I gains - register PID_VELOCITY_P_VELOCITY_I and PID_POSITION_P_POSITION_I
     pid_velocity_p_velocity_i: u32,
     pid_position_p_position_i: u32,
+    // The encoder PPR value - register ABN_DECODER_PPR
     abn_decoder_ppr: u32,
+    // ratio of motor's gearbox
     gearbox_ratio: f32,
+    // additional reduction ration of the axis
     axis_ratio: f32,
 
 }
@@ -17,63 +24,74 @@ impl BrushlessMotor {
     #[allow(dead_code)]
     pub fn ecx22() -> Self {
         Self {
-	    motor_type_n_pole_pairs: 0x00030004,
+            // 0x00030004: 3-phase brushless motor, 4 pole pairs
+            motor_type_n_pole_pairs: 0x00030004,
 
-	    //TODO!
-	    adc_i0_scale_offset: 0x010081D3,
-	    adc_i1_scale_offset: 0x0100825B,
+            //TODO!
+            adc_i0_scale_offset: 0x010081D3,
+            adc_i1_scale_offset: 0x0100825B,
 
-	    abn_decoder_ppr: 0x00001000,
+            // the encoder with 4096 ppr
+            abn_decoder_ppr: 0x00001000,
+            // PI controller params
             pid_flux_p_flux_i: 0x02000200,
             pid_torque_p_torque_i: 0x02000200,
             pid_velocity_p_velocity_i: 0x02000008,
             pid_position_p_position_i: 0x02000000,
 
-	    gearbox_ratio: 1.0/35.0,
-	    axis_ratio: 12.0/64.0,
-
+            // gearing ratios
+            gearbox_ratio: 1.0/35.0,
+            axis_ratio: 12.0/64.0
         }
     }
     #[allow(dead_code)]
     pub fn ec60() -> Self {
         Self {
-	    motor_type_n_pole_pairs: 0x00030007,
+            // 0x00030007: 3-phase brushless motor, 7 pole pairs
+            motor_type_n_pole_pairs: 0x00030007,
 
-	    //TODO!
-	    adc_i0_scale_offset: 0x010081FA,
-	    adc_i1_scale_offset: 0x0100826C,
+            //TODO!
+            adc_i0_scale_offset: 0x010081FA,
+            adc_i1_scale_offset: 0x0100826C,
 
-	    abn_decoder_ppr: 0x00001000,
+            // the encoder with 4096 ppr
+            abn_decoder_ppr: 0x00001000,
+            // PI controller params
             pid_flux_p_flux_i: 0x03200000,
             pid_torque_p_torque_i: 0x03200000,
             pid_velocity_p_velocity_i: 0x01F401C2,
             pid_position_p_position_i: 0x00500000,
-	    gearbox_ratio: 1.0,
-	    axis_ratio: 20.0/38.0,
+
+            // gearing ratios
+            gearbox_ratio: 1.0/25.0,
+            axis_ratio: 20.0/38.0
 
         }
     }
     #[allow(dead_code)]
     pub fn ec45() -> Self {
         Self {
-	    motor_type_n_pole_pairs: 0x00030004,
-	    // adc_i0_scale_offset: 0x002A819E, //Ventouse?
-	    // adc_i1_scale_offset: 0x002A821C,
-	    adc_i0_scale_offset: 0x0100819E,
-	    adc_i1_scale_offset: 0x0100821C,
+            // 0x00030007: 3-phase brushless motor, 8 pole pairs
+            motor_type_n_pole_pairs: 0x00030008,
 
-	    abn_decoder_ppr: 0x00000800,
+            // adc_i0_scale_offset: 0x002A819E, //Ventouse?
+            // adc_i1_scale_offset: 0x002A821C,
+            adc_i0_scale_offset: 0x0100819E,
+            adc_i1_scale_offset: 0x0100821C,
 
+            // the encoder with 4096 ppr
+            abn_decoder_ppr: 0x00001000,
+
+            // PI controller params
             // pid_flux_p_flux_i: 0x02000200,
             pid_flux_p_flux_i: 0x01000100,
             pid_torque_p_torque_i: 0x01000100,
-
             pid_velocity_p_velocity_i: 0x08000000,
             pid_position_p_position_i: 0x01000000,
-	    gearbox_ratio: 1.0,
-	    axis_ratio: 20.0/38.0,
 
-
+            // gearing ratios
+            gearbox_ratio: 1.0,
+            axis_ratio: 20.0/38.0,
 
         }
     }
@@ -109,6 +127,13 @@ impl BrushlessMotor {
     }
     pub fn axis_ratio(&self) -> f32 {
 	self.axis_ratio
+    }
+    pub fn pole_pairs(&self) -> f32 {
+	(self.motor_type_n_pole_pairs & 0x0000FFFF) as f32
+    }
+    // transformation gain form mechanical to electrical revolutions 
+    pub fn mech_to_elec(&self) -> f32 {
+	self.pole_pairs()/self.gearbox_ratio()
     }
 
     pub fn abn_decoder_ppr(&self) -> u32 {

--- a/src/config/motor.rs
+++ b/src/config/motor.rs
@@ -111,31 +111,59 @@ impl BrushlessMotor {
 	self.abn_decoder_ppr
     }
 
-    
+    // conversion from electrical to mechanical angle
+    // depending on the features enabled, 
+    // feature "gearbox_output" returns the angle after the gearbox
+    // feature "axis_output" returns the angle after the gearbox and axis
+    // if neither of the above features are enabled, the motor angle is returned
+    pub fn angle_elec_to_mech(&self, angle: f32) -> f32 {
+        #[cfg(feature = "gearbox_output")]
+        return self.elec_to_gearbox(angle);
+        #[cfg(feature = "axis_output")]
+        return self.elec_to_axis(angle);
+        // ide neither of the above features are enabled, the motor angle is returned
+        #[cfg(not(any(feature = "gearbox_output", feature = "axis_output")))]
+        return self.elec_to_shaft(angle);
+    }
+    // conversion from mechanical to electrical angle
+    // depends on the features enabled
+    // feature "gearbox_output" considers the angle after the gearbox
+    // feature "axis_output" considers the angle after the gearbox and axis
+    // if neither of the above features are enabled, the motor angle is returned
+    pub fn angle_mech_to_elec(&self, angle: f32) -> f32 {
+
+        #[cfg(feature = "gearbox_output")]
+        return self.gearbox_to_elec(angle);
+        #[cfg(feature = "axis_output")]
+        return self.axis_to_elec(angle);
+        // ide neither of the above features are enabled, the motor angle is returned
+        #[cfg(not(any(feature = "gearbox_output", feature = "axis_output")))]
+        return self.shaft_to_elec(angle);
+    }
 
     // conversion from electrical to mechanical angle
-    pub fn elec_to_mech(&self, angle: f32) -> f32 {
+    pub fn elec_to_shaft(&self, angle: f32) -> f32 {
         angle / self.pole_pairs()
     }
     // from electrical angle to the angle of the motor after the gearbox
-    pub fn elec_to_mech_gearbox(&self, angle: f32) -> f32 {
-        self.elec_to_mech(angle) * self.gearbox_ratio
+    pub fn elec_to_gearbox(&self, angle: f32) -> f32 {
+        self.elec_to_shaft(angle) * self.gearbox_ratio
     }
     // from electrical angle to the angle of the motor after the gearbox and axis
-    pub fn elec_to_mech_axis(&self, angle: f32) -> f32 {
-        self.elec_to_mech_axis(angle) * self.axis_ratio
+    pub fn elec_to_axis(&self, angle: f32) -> f32 {
+        self.elec_to_gearbox(angle) * self.axis_ratio
     }
     // conversion from mechanical to electrical angle
-    pub fn mech_to_elec(&self, angle: f32) -> f32 {
+    pub fn shaft_to_elec(&self, angle: f32) -> f32 {
         angle * self.pole_pairs() 
     }
     // from mechanical angle after the gearbox to electrical angle
-    pub fn mech_gearbox_to_elec(&self, angle: f32) -> f32 {
-        self.mech_to_elec(angle) / self.gearbox_ratio
+    pub fn gearbox_to_elec(&self, angle: f32) -> f32 {
+        self.shaft_to_elec(angle) / self.gearbox_ratio
     }
     // from mechanical angle after the gearbox and axis to electrical angle
-    pub fn mech_axis_to_elec(&self, angle: f32) -> f32 {
-        self.mech_axis_to_elec(angle) / self.axis_ratio
+    pub fn axis_to_elec(&self, angle: f32) -> f32 {
+        self.gearbox_to_elec(angle) / self.axis_ratio
     }
 
 }

--- a/src/config/motor.rs
+++ b/src/config/motor.rs
@@ -1,9 +1,6 @@
 pub struct BrushlessMotor {
     // 0x00030004: 3-phase brushless motor, 4 pole pairs - register MOTOR_TYPE_N_POLE_PAIRS
     motor_type_n_pole_pairs: u32,
-    // adc offset and scale values - register ADC_I0_SCALE_OFFSET and ADC_I1_SCALE_OFFSET
-    adc_i0_scale_offset: u32,
-    adc_i1_scale_offset: u32,
 
     // pid flux and torque P and I gains - register PID_FLUX_P_FLUX_I and PID_TORQUE_P_TORQUE_I
     pid_flux_p_flux_i: u32,
@@ -17,8 +14,8 @@ pub struct BrushlessMotor {
     gearbox_ratio: f32,
     // additional reduction ration of the axis
     axis_ratio: f32,
-
 }
+
 
 impl BrushlessMotor {
     #[allow(dead_code)]
@@ -26,10 +23,6 @@ impl BrushlessMotor {
         Self {
             // 0x00030004: 3-phase brushless motor, 4 pole pairs
             motor_type_n_pole_pairs: 0x00030004,
-
-            //TODO!
-            adc_i0_scale_offset: 0x010081D3,
-            adc_i1_scale_offset: 0x0100825B,
 
             // the encoder with 4096 ppr
             abn_decoder_ppr: 0x00001000,
@@ -41,7 +34,8 @@ impl BrushlessMotor {
 
             // gearing ratios
             gearbox_ratio: 1.0/35.0,
-            axis_ratio: 12.0/64.0
+            axis_ratio: 12.0/64.0,
+
         }
     }
     #[allow(dead_code)]
@@ -49,10 +43,6 @@ impl BrushlessMotor {
         Self {
             // 0x00030007: 3-phase brushless motor, 7 pole pairs
             motor_type_n_pole_pairs: 0x00030007,
-
-            //TODO!
-            adc_i0_scale_offset: 0x010081FA,
-            adc_i1_scale_offset: 0x0100826C,
 
             // the encoder with 4096 ppr
             abn_decoder_ppr: 0x00001000,
@@ -63,9 +53,8 @@ impl BrushlessMotor {
             pid_position_p_position_i: 0x00500000,
 
             // gearing ratios
-            gearbox_ratio: 1.0/25.0,
-            axis_ratio: 20.0/38.0
-
+            gearbox_ratio: 1.0/25.01,
+            axis_ratio: 28.0/52.0,
         }
     }
     #[allow(dead_code)]
@@ -73,11 +62,6 @@ impl BrushlessMotor {
         Self {
             // 0x00030007: 3-phase brushless motor, 8 pole pairs
             motor_type_n_pole_pairs: 0x00030008,
-
-            // adc_i0_scale_offset: 0x002A819E, //Ventouse?
-            // adc_i1_scale_offset: 0x002A821C,
-            adc_i0_scale_offset: 0x0100819E,
-            adc_i1_scale_offset: 0x0100821C,
 
             // the encoder with 4096 ppr
             abn_decoder_ppr: 0x00001000,
@@ -92,23 +76,14 @@ impl BrushlessMotor {
             // gearing ratios
             gearbox_ratio: 1.0,
             axis_ratio: 20.0/38.0,
-
         }
     }
 }
 
 impl BrushlessMotor {
     pub fn motor_type_n_pole_pairs(&self) -> u32 {
-		self.motor_type_n_pole_pairs
+	self.motor_type_n_pole_pairs
     }
-    pub fn adc_i0_scale_offset(&self) -> u32 {
-	self.adc_i0_scale_offset
-    }
-    pub fn adc_i1_scale_offset(&self) -> u32 {
-	self.adc_i1_scale_offset
-    }
-
-
     pub fn pid_flux_p_flux_i(&self) -> u32 {
         self.pid_flux_p_flux_i
     }
@@ -131,14 +106,36 @@ impl BrushlessMotor {
     pub fn pole_pairs(&self) -> f32 {
 	(self.motor_type_n_pole_pairs & 0x0000FFFF) as f32
     }
-    // transformation gain form mechanical to electrical revolutions 
-    pub fn mech_to_elec(&self) -> f32 {
-	self.pole_pairs()/self.gearbox_ratio()
-    }
-
+    
     pub fn abn_decoder_ppr(&self) -> u32 {
 	self.abn_decoder_ppr
     }
 
+    
+
+    // conversion from electrical to mechanical angle
+    pub fn elec_to_mech(&self, angle: f32) -> f32 {
+        angle / self.pole_pairs()
+    }
+    // from electrical angle to the angle of the motor after the gearbox
+    pub fn elec_to_mech_gearbox(&self, angle: f32) -> f32 {
+        self.elec_to_mech(angle) * self.gearbox_ratio
+    }
+    // from electrical angle to the angle of the motor after the gearbox and axis
+    pub fn elec_to_mech_axis(&self, angle: f32) -> f32 {
+        self.elec_to_mech_axis(angle) * self.axis_ratio
+    }
+    // conversion from mechanical to electrical angle
+    pub fn mech_to_elec(&self, angle: f32) -> f32 {
+        angle * self.pole_pairs() 
+    }
+    // from mechanical angle after the gearbox to electrical angle
+    pub fn mech_gearbox_to_elec(&self, angle: f32) -> f32 {
+        self.mech_to_elec(angle) / self.gearbox_ratio
+    }
+    // from mechanical angle after the gearbox and axis to electrical angle
+    pub fn mech_axis_to_elec(&self, angle: f32) -> f32 {
+        self.mech_axis_to_elec(angle) / self.axis_ratio
+    }
 
 }

--- a/src/dynamixel/hwi.ipynb
+++ b/src/dynamixel/hwi.ipynb
@@ -143,7 +143,7 @@
     "    packet = DxlReadDataPacket(poulpe_id, 10, N_AXIS * 4)\n",
     "    resp = dxl_io._send_packet(packet,wait_for_status_packet=True)\n",
     "    data = bytearray(resp.parameters)\n",
-    "    pos = struct.unpack(N_AXIS * 'I', data)\n",
+    "    pos = struct.unpack(N_AXIS * 'f', data)\n",
     "    return pos\n",
     "\n",
     "read_velocity_limit()"
@@ -172,7 +172,7 @@
    "outputs": [],
    "source": [
     "def write_velocity_limit(data): #array of N_AXIS*u32\n",
-    "    packet = DxlWriteDataPacket(poulpe_id, 10, struct.pack(N_AXIS * 'I', *data))\n",
+    "    packet = DxlWriteDataPacket(poulpe_id, 10, struct.pack(N_AXIS * 'f', *data))\n",
     "    resp = dxl_io._send_packet(packet,wait_for_status_packet=True)\n",
     "    return resp"
    ]

--- a/src/dynamixel/hwi.ipynb
+++ b/src/dynamixel/hwi.ipynb
@@ -200,7 +200,7 @@
     "    packet = DxlReadDataPacket(poulpe_id, 14, N_AXIS * 2)\n",
     "    resp = dxl_io._send_packet(packet,wait_for_status_packet=True)\n",
     "    data = bytearray(resp.parameters)\n",
-    "    pos = struct.unpack(N_AXIS * 'H', data)\n",
+    "    pos = struct.unpack(N_AXIS * 'f', data)\n",
     "    return pos\n",
     "\n",
     "read_torqueflux_limit()"
@@ -213,7 +213,7 @@
    "outputs": [],
    "source": [
     "def write_torqueflux_limit(data): #array of N_AXIS*u16\n",
-    "    packet = DxlWriteDataPacket(poulpe_id, 14, struct.pack(N_AXIS * H', *data))\n",
+    "    packet = DxlWriteDataPacket(poulpe_id, 14, struct.pack(N_AXIS * 'f', *data))\n",
     "    resp = dxl_io._send_packet(packet,wait_for_status_packet=True)\n",
     "    return resp"
    ]

--- a/src/dynamixel/register.rs
+++ b/src/dynamixel/register.rs
@@ -55,13 +55,13 @@ impl DynamixelRegister {
 
 
 
-        40 => Some(DynamixelRegister::TorqueEnable),
-        50 => Some(DynamixelRegister::CurrentPosition),
-        51 => Some(DynamixelRegister::CurrentVelocity),
-        52 => Some(DynamixelRegister::CurrentTorque),
+            40 => Some(DynamixelRegister::TorqueEnable),
+            51 => Some(DynamixelRegister::CurrentVelocity),
+            50 => Some(DynamixelRegister::CurrentPosition),
 	    54 => Some(DynamixelRegister::FeedforwardVelocity),
-        60 => Some(DynamixelRegister::TargetPosition),
-        62 => Some(DynamixelRegister::TargetPositionWithVelocityFF),
+            52 => Some(DynamixelRegister::CurrentTorque),
+            62 => Some(DynamixelRegister::TargetPositionWithVelocityFF),
+            60 => Some(DynamixelRegister::TargetPosition),
 
 	    90 => Some(DynamixelRegister::AxisSensor),
 

--- a/src/dynamixel/task.rs
+++ b/src/dynamixel/task.rs
@@ -180,7 +180,7 @@ pub async fn messsage_handler(usart: config::DynamixelUart, dir_pin: AnyPin) {
 
                             DynamixelRegister::VelocityLimit => {
                                 let value = { SHARED_MEMORY.lock().await.get_velocity_limit() };
-                                let value = conversion::u32_to_bytes(value);
+                                let value = conversion::float_to_bytes(value);
                                 let sp = StatusPacket::with_value(id, dxl_error, value);
                                 trace!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
                                 if let Some(e) = dxl.write(&sp).await.err() {
@@ -364,8 +364,8 @@ pub async fn messsage_handler(usart: config::DynamixelUart, dir_pin: AnyPin) {
 
                             DynamixelRegister::VelocityLimit => {
 
-				let limits: [u32; config::N_AXIS] =
-				    conversion::bytes_to_u32(write_data_packet.data);
+				let limits: [f32; config::N_AXIS] =
+				    conversion::bytes_to_float(write_data_packet.data);
 				{
 				    SHARED_MEMORY.lock().await.set_velocity_limit(limits);
 				}

--- a/src/dynamixel/task.rs
+++ b/src/dynamixel/task.rs
@@ -169,7 +169,7 @@ pub async fn messsage_handler(usart: config::DynamixelUart, dir_pin: AnyPin) {
 
                             DynamixelRegister::TorqueFluxLimit => {
                                 let value = { SHARED_MEMORY.lock().await.get_torque_flux_limit() };
-                                let value = conversion::u16_to_bytes(value);
+                                let value = conversion::float_to_bytes(value);
                                 let sp = StatusPacket::with_value(id, dxl_error, value);
                                 trace!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
                                 if let Some(e) = dxl.write(&sp).await.err() {
@@ -349,8 +349,8 @@ pub async fn messsage_handler(usart: config::DynamixelUart, dir_pin: AnyPin) {
 
                             DynamixelRegister::TorqueFluxLimit => {
 
-				let limits: [u16; config::N_AXIS] =
-				    conversion::bytes_to_u16(write_data_packet.data);
+				let limits: [f32; config::N_AXIS] =
+				    conversion::bytes_to_float(write_data_packet.data);
 				{
 				    SHARED_MEMORY.lock().await.set_torque_flux_limit(limits);
 				}
@@ -403,7 +403,6 @@ pub async fn messsage_handler(usart: config::DynamixelUart, dir_pin: AnyPin) {
                                     SHARED_MEMORY.lock().await.set_target_position(target);
                                 }
 
-
 				//return the full state
 				let value={ SHARED_MEMORY.lock().await.get_full_state() };
                                 let value  = conversion::float_to_bytes(value);
@@ -426,13 +425,13 @@ pub async fn messsage_handler(usart: config::DynamixelUart, dir_pin: AnyPin) {
                                 {
                                     SHARED_MEMORY.lock().await.set_target_position(target);
                                 }
+
                                 // then the velocity feedforward
                                 let velocity_feedforward: [f32; config::N_AXIS] =
                                     conversion::bytes_to_float(write_data_packet.data[4*config::N_AXIS..8*config::N_AXIS].try_into().unwrap());
                                 {
                                     SHARED_MEMORY.lock().await.set_velocity_feedforward(velocity_feedforward);
                                 }
-
 
 				//return the full state
 				let value={ SHARED_MEMORY.lock().await.get_full_state() };
@@ -444,7 +443,6 @@ pub async fn messsage_handler(usart: config::DynamixelUart, dir_pin: AnyPin) {
                                 if let Some(e) = dxl.write(&sp).await.err() {
                                     error!("Error: {:?}", e);
                                 }
-
 
 
                             }

--- a/src/motor_control/actuator.rs
+++ b/src/motor_control/actuator.rs
@@ -268,8 +268,8 @@ impl<'d, const N: usize> RawMotorsIO<N> for Actuator<'d, N> {
     }
 
     /// Get the torque limit of the motors (in Nm)
-    fn get_torque_flux_limit(&mut self) -> Result<[u16; N]> {
-        let mut res = [0; N];
+    fn get_torque_flux_limit(&mut self) -> Result<[f32; N]> {
+        let mut res = [0.0; N];
         for (i, axis) in self.axes.iter_mut().enumerate() {
             res[i] = axis.get_torque_flux_limit()?[0];
         }
@@ -277,7 +277,7 @@ impl<'d, const N: usize> RawMotorsIO<N> for Actuator<'d, N> {
         Ok(res)
     }
     /// Set the torque limit of the motors (in Nm)
-    fn set_torque_flux_limit(&mut self, torque: [u16; N]) -> Result<()> {
+    fn set_torque_flux_limit(&mut self, torque: [f32; N]) -> Result<()> {
         for (i, axis) in self.axes.iter_mut().enumerate() {
             axis.set_torque_flux_limit([torque[i]])?;
         }

--- a/src/motor_control/actuator.rs
+++ b/src/motor_control/actuator.rs
@@ -250,8 +250,8 @@ impl<'d, const N: usize> RawMotorsIO<N> for Actuator<'d, N> {
 
 
     /// Get the velocity limit of the motors (in radians per second)
-    fn get_velocity_limit(&mut self) -> Result<[u32; N]> {
-        let mut res = [0; N];
+    fn get_velocity_limit(&mut self) -> Result<[f32; N]> {
+        let mut res = [0.0; N];
         for (i, axis) in self.axes.iter_mut().enumerate() {
             res[i] = axis.get_velocity_limit()?[0];
         }
@@ -259,7 +259,7 @@ impl<'d, const N: usize> RawMotorsIO<N> for Actuator<'d, N> {
         Ok(res)
     }
     /// Set the velocity limit of the motors (in radians per second)
-    fn set_velocity_limit(&mut self, velocity: [u32; N]) -> Result<()> {
+    fn set_velocity_limit(&mut self, velocity: [f32; N]) -> Result<()> {
         for (i, axis) in self.axes.iter_mut().enumerate() {
             axis.set_velocity_limit([velocity[i]])?;
         }

--- a/src/motor_control/foc.rs
+++ b/src/motor_control/foc.rs
@@ -27,11 +27,20 @@ const DS_ADC_MCFG_B_MCFG_A: u32 = 0x00100010;
 const DS_ADC_MCLK_A: u32 = 0x20000000;
 const DS_ADC_MCLK_B: u32 = 0x00000000;
 const DS_ADC_MDEC_B_MDEC_A: u32 = 0x014E014E;
+// full resolution of the ADC is 2^16 - 1
+// bidirectional current measurement is used
+// center is around 2^15 - 1
+pub const ADC_RESOLUTION: f32 = 65535.0; // 16 bit 
 
 // ABN encoder settings
 const ABN_DECODER_MODE: u32 = 0x00000000;
 // const ABN_DECODER_PPR: u32 = 0x00001000;
 const ABN_DECODER_PHI_E_PHI_M_OFFSET: u32 = 0x00000000;
+
+
+// in TMC4671 one electrical revolution 
+// is always represented with 16 bits
+pub const PPR_PER_ELECTRICAL_REVOLUTION: f32 = 65535.0; // 16 bit
 
 // Limits
 // const PID_TORQUE_FLUX_LIMITS: u32 = 0x00001000; // 4096
@@ -48,7 +57,6 @@ const PID_VELOCITY_LIMIT: u32 = 0x0000_7D00; //32000 //tuned ok at 500Hz
 pub const OPENLOOP_ACCELERATION: u32 = 0x0000003c; // Wizard default
 // pub const UQ_UD_EXT: u32 = 0x000007D0; // Openloop "torque_target" 2000
 pub const UQ_UD_EXT: u32 = 0x000001000; // Openloop "torque_target" 2000
-
 
 
 #[allow(non_camel_case_types)]
@@ -198,7 +206,9 @@ where
     //     #[allow(dead_code)]
     //     foc_status: Input<'d, FocStat>,
     pub brushless_motor_config: config::BrushlessMotor,
-    pub(crate) ppr: Option<f32>,
+    pub current_sensing_config: config::CurrentSensing,
+    pub ppr: f32,
+    pub adc_resolution: f32,
 }
 
 impl<'d, T, P, EnablePin> Foc<'d, T, P, EnablePin>
@@ -216,6 +226,7 @@ where
         >,
         enable: EnablePin,
         brushless_motor_config: config::BrushlessMotor,
+        current_sensing_config: config::CurrentSensing
     ) -> Self {
         let mut enable = Output::new(enable, Level::Low, Speed::Low);
         enable.set_low();
@@ -224,7 +235,9 @@ where
             spi,
             enable,
             brushless_motor_config,
-            ppr: None,
+            current_sensing_config,
+            ppr: PPR_PER_ELECTRICAL_REVOLUTION,
+            adc_resolution: ADC_RESOLUTION,
         }
     }
 
@@ -306,7 +319,7 @@ where
 	self.tmc4671_get_lower_u16(Tmc4671Registers::PID_TORQUE_FLUX_LIMITS as u8)
     }
     pub fn tmc4671_set_torque_flux_limit(&mut self, limit:u16) -> Result<u32, embassy_stm32::spi::Error> {
-	self.tmc4671_write_register(Tmc4671Registers::PID_TORQUE_FLUX_LIMITS as u8, limit as u32 &0x7FFF as u32)
+	self.tmc4671_write_register(Tmc4671Registers::PID_TORQUE_FLUX_LIMITS as u8, limit as u32 & 0x7FFF as u32)
     }
 
     pub fn tmc4671_get_velocity_limit(&mut self) -> Result<u32, embassy_stm32::spi::Error> {
@@ -507,11 +520,11 @@ where
         )?;
         self.tmc4671_checked_write(
             Tmc4671Registers::ADC_I1_SCALE_OFFSET as u8,
-            self.brushless_motor_config.adc_i1_scale_offset(),
+            self.current_sensing_config.adc_i1_scale_offset(),
         )?;
         self.tmc4671_checked_write(
             Tmc4671Registers::ADC_I0_SCALE_OFFSET as u8,
-            self.brushless_motor_config.adc_i0_scale_offset(),
+            self.current_sensing_config.adc_i0_scale_offset(),
         )?;
 
         // ABN encoder settings

--- a/src/motor_control/motors_io.rs
+++ b/src/motor_control/motors_io.rs
@@ -78,9 +78,9 @@ pub trait RawMotorsIO<const N: usize> {
     fn set_torque_flux_limit(&mut self, limit: [u16; N]) -> Result<()>;
 
     /// Get the velocity limit of the motors (in radians per second)
-    fn get_velocity_limit(&mut self) -> Result<[u32; N]>;
+    fn get_velocity_limit(&mut self) -> Result<[f32; N]>;
     /// Set the velocity limit of the motors (in radians per second)
-    fn set_velocity_limit(&mut self, limit: [u32; N]) -> Result<()>;
+    fn set_velocity_limit(&mut self, limit: [f32; N]) -> Result<()>;
 
     // /// Get the torque limit of the motors (in Nm)
     // fn get_torque_limit(&mut self) -> Result<[f32; N]>;

--- a/src/motor_control/motors_io.rs
+++ b/src/motor_control/motors_io.rs
@@ -73,9 +73,9 @@ pub trait RawMotorsIO<const N: usize> {
     fn set_uq_ud_limit(&mut self, limit: [i16; N]) -> Result<()>;
 
     /// Get torque/flux limit
-    fn get_torque_flux_limit(&mut self) -> Result<[u16; N]>;
+    fn get_torque_flux_limit(&mut self) -> Result<[f32; N]>;
     /// Set torque/flux limit
-    fn set_torque_flux_limit(&mut self, limit: [u16; N]) -> Result<()>;
+    fn set_torque_flux_limit(&mut self, limit: [f32; N]) -> Result<()>;
 
     /// Get the velocity limit of the motors (in radians per second)
     fn get_velocity_limit(&mut self) -> Result<[f32; N]>;

--- a/src/motor_control/task.rs
+++ b/src/motor_control/task.rs
@@ -199,11 +199,12 @@ pub async fn control_loop(config: ActuatorConfig) {
         config.b.foc_enable,
 	#[cfg(all(feature = "orbita2d", feature = "ec45"))]
         config::BrushlessMotor::ec45(),
-	#[cfg(all(feature = "orbita2d", feature = "ec60"))]
+        #[cfg(all(feature = "orbita2d", feature = "ec60"))]
         config::BrushlessMotor::ec60(),
 	#[cfg(feature = "orbita3d")]
         config::BrushlessMotor::ecx22(),
-
+        // current sense for wailer B2 board
+        config::CurrentSensing::wailer_B2()
     );
 
     let driver_spi = SpiDeviceWithConfig::new(
@@ -243,6 +244,8 @@ pub async fn control_loop(config: ActuatorConfig) {
         config::BrushlessMotor::ec60(),
 	#[cfg(feature = "orbita3d")]
         config::BrushlessMotor::ecx22(),
+        // current sense for wailer B2 board
+        config::CurrentSensing::wailer_B2()
     );
 
     let driver_spi = SpiDeviceWithConfig::new(
@@ -569,21 +572,21 @@ pub async fn control_loop(config: ActuatorConfig) {
 							    }
 	);
 
-    // add the feedforward control to the velocity loop
-    #[cfg(feature = "velocity_feedforward")]
-    {
-        // velocity feedforward from shared memory
-        let mut velocity_ff = { SHARED_MEMORY.lock().await.get_velocity_feedforward() };
-        // filter the velocity feedforward
-        velocity_ff.iter_mut().enumerate().for_each(|(i,v)| {*v=vel_ff_filter[i].run(*v)});
-        // set the velocity feedforward
-        actuator.set_velocity_feedforward(velocity_ff).unwrap_or_else(|e|
-            {
-                error!("Error setting velocity feedforward: {:?}", e);
-                error_led=true;
-            }
-        );
-    }
+        // add the feedforward control to the velocity loop
+        #[cfg(feature = "velocity_feedforward")]
+        {
+                // velocity feedforward from shared memory
+                let mut velocity_ff = { SHARED_MEMORY.lock().await.get_velocity_feedforward() };
+                // filter the velocity feedforward
+                velocity_ff.iter_mut().enumerate().for_each(|(i,v)| {*v=vel_ff_filter[i].run(*v)});
+                // set the velocity feedforward
+                actuator.set_velocity_feedforward(velocity_ff).unwrap_or_else(|e|
+                {
+                        error!("Error setting velocity feedforward: {:?}", e);
+                        error_led=true;
+                }
+                );
+        }
 
 
 
@@ -625,6 +628,7 @@ pub async fn control_loop(config: ActuatorConfig) {
 		if ! sensors.iter().any(|s| s.is_nan()) { //FIXME: hope it the sensor reading will better work to remove this
 		    SHARED_MEMORY.lock().await.set_axis_sensor(sensors);
 		}
+
 
 
 		// info!("sensors: {:?}", sensors);

--- a/src/motor_control/ventouse.rs
+++ b/src/motor_control/ventouse.rs
@@ -102,18 +102,6 @@ where
 
 	}
 
-        // TMC4671 has 32bit position register in PID_POSITION_ACTUAL
-        // regardless of the resolution of the encoder, one electrical revolution is represented with lower 16 bits
-        // This means that one mechanical revolution can will result in number of motor's pole pairs x 2^16 counts
-        // ex. ec45 which has 8 pole pairs will have 8x2^16 = 2^19 = 524288 counts per mechanical revolution
-        // additionally as motors can have gearboxes, we need to multiply by gearbox ratio as well
-        self.foc.ppr=Some(
-            self.foc.brushless_motor_config.pole_pairs() * 65536.0 / self.foc.brushless_motor_config.gearbox_ratio()
-        ); 
-
-    
-
-
         match self.align_motor().await
 	{
 	    Ok(_) => info!("[Ventouse{:?}] align done",self.kind),
@@ -332,8 +320,8 @@ where
 	self
             .foc
             .tmc4671_set_actual_position(conversion::rad_to_encoder(
-                pos[0],
-                self.foc.ppr.unwrap())
+                self.foc.brushless_motor_config.mech_gearbox_to_elec(pos[0]), // mechanical to electrical angle
+                self.foc.ppr)
             ).map_err(IOError::SpiError)?;
 	Ok(())
 
@@ -345,11 +333,12 @@ where
             .foc
             .tmc4671_get_actual_position()
             .map_err(IOError::SpiError)?;
-        let rads = conversion::encoder_to_rad(
-            encoder, 
-            self.foc.ppr.unwrap()
-        );
-        Ok([rads])
+        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox( // electrical to mechanical angle
+                conversion::encoder_to_rad(
+                        encoder, 
+                        self.foc.ppr
+                )
+        )])
     }
     /// Get the current velocity of the motors (in radians per second)
     fn get_current_velocity(&mut self) -> Result<[f32; 1], IOError> {
@@ -357,19 +346,19 @@ where
 	    foc.
 	    tmc4671_get_actual_velocity()
 	    .map_err(IOError::SpiError)?;
-        let vel_rads = conversion::rpm_to_rads(
-            (vel as f32)/self.foc.brushless_motor_config.mech_to_elec()
-        );
-        Ok([vel_rads as f32]) 
+        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox(
+                conversion::rpm_to_rads(vel as f32)
+        )]) 
     }
 
-    /// Get the current torque of the motors (in Nm)
+    /// Get the current torque of the motors (in Nm) 
+    /// for now its in mAmps
     fn get_current_torque(&mut self) -> Result<[f32; 1], IOError> {
 	let torque=self.
 	    foc.
 	    tmc4671_get_torque_actual()
 	    .map_err(IOError::SpiError)?;
-	Ok([torque as f32]) //TODO is there a conversion to do?
+        Ok([self.foc.current_sensing_config.adc_to_mAmps(torque as f32, self.foc.adc_resolution)]) 
 
     }
 
@@ -379,27 +368,29 @@ where
 	    foc.
 	    tmc4671_get_target_position()
 	    .map_err(IOError::SpiError)?;
-    	Ok([conversion::encoder_to_rad(
-            pos, 
-            self.foc.ppr.unwrap()
+    	Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox( // electrical to mechanical position
+                conversion::encoder_to_rad(
+                        pos, 
+                        self.foc.ppr
+                )
         )])
     }
     /// Set the current target position of the motors output (in radians)
     fn set_target_position(&mut self, position: [f32; 1]) -> Result<(), IOError> {
         self.foc
             .tmc4671_set_target_position(conversion::rad_to_encoder(
-                position[0],
-                self.foc.ppr.unwrap(),
-            ))
+                self.foc.brushless_motor_config.mech_gearbox_to_elec(position[0]), // mechanical to electrical angle
+                self.foc.ppr)
+            )
             .map(|_| ())
             .map_err(IOError::SpiError)
     }
 
     /// Set the current velocity feedforward (in radians per second)
     fn set_velocity_feedforward(&mut self, velocity: [f32; 1]) -> Result<(), IOError> {
-        let vel_rpm = conversion::rads_to_rpm(
-            velocity[0]*self.foc.brushless_motor_config.mech_to_elec()
-        );
+        let vel_rpm =self.foc.brushless_motor_config.mech_gearbox_to_elec(
+                conversion::rads_to_rpm(velocity[0] as f32)
+            );
         self.foc
             .tmc4671_set_velocity_offset(vel_rpm as i32 )
             .map(|_| ())
@@ -411,10 +402,9 @@ where
            foc.
            tmc4671_get_velocity_offset()
            .map_err(IOError::SpiError)?;
-        let vel_rads = conversion::rpm_to_rads(
-            (vel as f32)/self.foc.brushless_motor_config.mech_to_elec(),
-        );
-        Ok([vel_rads as f32]) 
+        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox(
+                conversion::rpm_to_rads(vel as f32)
+        )]) 
     }
 
 
@@ -425,16 +415,16 @@ where
 	    foc.
 	    tmc4671_get_target_velocity()
 	    .map_err(IOError::SpiError)?;
-        let vel_rads = conversion::rpm_to_rads(
-            (vel as f32)/self.foc.brushless_motor_config.mech_to_elec(),
-        );
-        Ok([vel_rads as f32]) 
+        
+        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox(
+            conversion::rpm_to_rads(vel as f32)
+        )]) 
     }
     // set new target velocity (in radians per second)
     fn set_target_velocity(&mut self, velocity: [f32; 1]) -> Result<(), IOError> {
-        let vel_rpm = conversion::rads_to_rpm(
-            velocity[0]*self.foc.brushless_motor_config.mech_to_elec()
-        );
+        let vel_rpm = self.foc.brushless_motor_config.mech_gearbox_to_elec(
+                conversion::rads_to_rpm(velocity[0] as f32)
+            );
         self.foc
             .tmc4671_set_target_velocity(
                 vel_rpm as i32) 
@@ -443,18 +433,22 @@ where
     }
 
 
+    /// Get the target torque of the motors (in Nm) 
+    /// for now its in mAmps
     fn get_target_torque(&mut self) -> Result<[f32; 1], IOError> {
-        let pos=self.
+        let torque =self.
 	    foc.
 	    tmc4671_get_target_torque()
 	    .map_err(IOError::SpiError)?;
-	Ok([pos as f32])
+	Ok([self.foc.current_sensing_config.adc_to_mAmps(torque as f32, self.foc.adc_resolution)])
     }
 
     fn set_target_torque(&mut self, torque: [f32; 1]) -> Result<(), IOError> {
+        // torque from mAmps to ADC counts
+        let torque_adc = self.foc.current_sensing_config.mAmps_tp_adc(torque[0], self.foc.adc_resolution);
         self.foc
             .tmc4671_set_target_torque(
-                torque[0] as i32)// TODO convert to mA
+                torque_adc as i32)// TODO convert to mA
             .map(|_| ())
             .map_err(IOError::SpiError)
     }
@@ -463,7 +457,7 @@ where
 
     /// Get the uq_ud limit of the motors
     fn get_uq_ud_limit(&mut self) -> Result<[i16; 1], IOError> {
-	//TODO Conversion. Is it in rpm?
+	//TODO Conversion 
         let limit=self.foc.tmc4671_get_uq_ud_limit()
             .map_err(IOError::SpiError)?;
 	Ok([limit as i16])
@@ -478,39 +472,38 @@ where
     }
 
 
-    /// Get the torque_flux limit of the motors
-    fn get_torque_flux_limit(&mut self) -> Result<[u16; 1], IOError> {
-	//TODO Conversion. Is it in rpm?
+    /// Get the flux torque limits of the motors mAmps
+    fn get_torque_flux_limit(&mut self) -> Result<[f32; 1], IOError> {
         let limit=self.foc.tmc4671_get_torque_flux_limit()
             .map_err(IOError::SpiError)?;
-	Ok([limit as u16])
+	Ok([self.foc.current_sensing_config.adc_to_mAmps(limit as f32, self.foc.adc_resolution)])
 
     }
     /// Set the torque_flux limit of the motors
-    fn set_torque_flux_limit(&mut self, limit: [u16; 1]) -> Result<(), IOError> {
-	self.foc.tmc4671_set_torque_flux_limit(limit[0] as u16)
+    fn set_torque_flux_limit(&mut self, limit: [f32; 1]) -> Result<(), IOError> {
+        // limit from mAmps to ADC counts
+        let limit_adc = self.foc.current_sensing_config.mAmps_tp_adc(limit[0], self.foc.adc_resolution);
+	self.foc.tmc4671_set_torque_flux_limit(limit_adc as u16)
 			.map(|_| ())
 			.map_err(IOError::SpiError)
-
     }
 
 
     /// Get the velocity limit of the motors (in radians per second)
     fn get_velocity_limit(&mut self) -> Result<[f32; 1], IOError> {
-	//TODO Conversion. Is it in rpm?
         let limit=self.foc.tmc4671_get_velocity_limit()
             .map_err(IOError::SpiError)?;
         // limit in rad/s
-        Ok([conversion::rpm_to_rads(
-            (limit as f32)/self.foc.brushless_motor_config.mech_to_elec()
-        )])
+        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox(
+                conversion::rpm_to_rads(limit as f32)
+            )]) 
 
     }
     /// Set the velocity limit of the motors (in radians per second)
     fn set_velocity_limit(&mut self, limit: [f32; 1]) -> Result<(), IOError> {
-        let limit_rpm = conversion::rads_to_rpm(
-            limit[0]*self.foc.brushless_motor_config.mech_to_elec()
-        );
+        let limit_rpm = self.foc.brushless_motor_config.mech_gearbox_to_elec(
+                conversion::rads_to_rpm(limit[0] as f32)
+            );
 	self.foc.tmc4671_set_velocity_limit(limit_rpm as u32)
 			.map(|_| ())
 			.map_err(IOError::SpiError)
@@ -669,7 +662,7 @@ where
 	};
 
 
-	self.set_target_velocity([5500.0])?;
+	self.set_target_velocity([10.0])?; // move with 10 rad/s (on gearbox side)
 	self.set_control_mode(MotionMode::Velocity)?;
 	block_for(Duration::from_millis(500)); //It should move the arm roughly 11°
 	//debug
@@ -677,13 +670,13 @@ where
 	    error!("GET POS error: {:?}",e);
 	    0
 	});
-	let rads = conversion::encoder_to_rad(pos, self.foc.ppr.unwrap())*self.foc.brushless_motor_config.gearbox_ratio();//*self.foc.brushless_motor_config.axis_ratio();
+	let rads = self.foc.brushless_motor_config.elec_to_mech_gearbox(conversion::encoder_to_rad(pos, self.foc.ppr));
 	let start_indices=compute_idx(d);
 	debug!("Start indices: {:?} start pos: {:?}",start_indices, rads.to_degrees());
 
 
 
-	self.set_target_velocity([-5500.0])?;
+	self.set_target_velocity([10.0])?; // move with -10 rad/s (on gearbox side)
 	// self.set_control_mode(MotionMode::Velocity)?;
 	let t0=Instant::now();
 	let mut dd=donut_sensor.read().unwrap_or_else(|e| {
@@ -705,8 +698,7 @@ where
 	    error!("GET POS error: {:?}",e);
 	    0
 	});
-	let rads2 = conversion::encoder_to_rad(pos, self.foc.ppr.unwrap())*self.foc.brushless_motor_config.gearbox_ratio();//*self.foc.brushless_motor_config.axis_ratio();
-
+	let rads2 = self.foc.brushless_motor_config.elec_to_mech_gearbox(conversion::encoder_to_rad(pos, self.foc.ppr));
 
 
 
@@ -921,8 +913,6 @@ impl<'d> RawMotorsIO<1> for VentouseKind<'d> {
     }
 
 
-
-
     fn get_target_torque(&mut self) -> Result<[f32; 1], IOError> {
         match self {
             VentouseKind::A(va) => va.get_target_torque(),
@@ -958,16 +948,16 @@ impl<'d> RawMotorsIO<1> for VentouseKind<'d> {
         }
     }
 
-    /// Get the torque_flux limit of the motors (in Nm)
-    fn get_torque_flux_limit(&mut self) -> Result<[u16; 1], IOError> {
+    /// Get the torque_flux limit of the motors (in mAmps)
+    fn get_torque_flux_limit(&mut self) -> Result<[f32; 1], IOError> {
         match self {
             VentouseKind::A(va) => va.get_torque_flux_limit(),
             VentouseKind::B(vb) => vb.get_torque_flux_limit(),
             VentouseKind::C(vc) => vc.get_torque_flux_limit(),
         }
     }
-    /// Set the torque_flux limit of the motors (in Nm)
-    fn set_torque_flux_limit(&mut self, torque_flux: [u16; 1]) -> Result<(), IOError> {
+    /// Set the torque_flux limit of the motors (in mAmps)
+    fn set_torque_flux_limit(&mut self, torque_flux: [f32; 1]) -> Result<(), IOError> {
         match self {
             VentouseKind::A(va) => va.set_torque_flux_limit(torque_flux),
             VentouseKind::B(vb) => vb.set_torque_flux_limit(torque_flux),
@@ -975,7 +965,7 @@ impl<'d> RawMotorsIO<1> for VentouseKind<'d> {
         }
     }
 
-    /// Get the uq_ud limit of the motors (in Nm)
+    /// Get the uq_ud limit of the motors 
     fn get_uq_ud_limit(&mut self) -> Result<[i16; 1], IOError> {
         match self {
             VentouseKind::A(va) => va.get_uq_ud_limit(),
@@ -983,7 +973,7 @@ impl<'d> RawMotorsIO<1> for VentouseKind<'d> {
             VentouseKind::C(vc) => vc.get_uq_ud_limit(),
         }
     }
-    /// Set the uq_ud limit of the motors (in Nm)
+    /// Set the uq_ud limit of the motors 
     fn set_uq_ud_limit(&mut self, uq_ud: [i16; 1]) -> Result<(), IOError> {
         match self {
             VentouseKind::A(va) => va.set_uq_ud_limit(uq_ud),

--- a/src/motor_control/ventouse.rs
+++ b/src/motor_control/ventouse.rs
@@ -102,10 +102,16 @@ where
 
 	}
 
+        // TMC4671 has 32bit position register in PID_POSITION_ACTUAL
+        // regardless of the resolution of the encoder, one electrical revolution is represented with lower 16 bits
+        // This means that one mechanical revolution can will result in number of motor's pole pairs x 2^16 counts
+        // ex. ec45 which has 8 pole pairs will have 8x2^16 = 2^19 = 524288 counts per mechanical revolution
+        // additionally as motors can have gearboxes, we need to multiply by gearbox ratio as well
+        self.foc.ppr=Some(
+            self.foc.brushless_motor_config.pole_pairs() * 65536.0 / self.foc.brushless_motor_config.gearbox_ratio()
+        ); 
 
-        // self.foc.ppr = Some(self.foc.tmc4671_get_encoder_ppr()? as f32);
-	self.foc.ppr=Some(524288.0/(2.0*3.141592)); //It seems that 524288=360° motor (0x80000)
-
+    
 
 
         match self.align_motor().await
@@ -325,7 +331,10 @@ where
     fn set_current_position(&mut self, pos:[f32;1]) -> Result<(), IOError> {
 	self
             .foc
-            .tmc4671_set_actual_position(conversion::rads_to_encoder(pos[0],self.foc.ppr.unwrap()/self.foc.brushless_motor_config.gearbox_ratio())).map_err(IOError::SpiError)?;
+            .tmc4671_set_actual_position(conversion::rad_to_encoder(
+                pos[0],
+                self.foc.ppr.unwrap())
+            ).map_err(IOError::SpiError)?;
 	Ok(())
 
     }
@@ -336,7 +345,10 @@ where
             .foc
             .tmc4671_get_actual_position()
             .map_err(IOError::SpiError)?;
-        let rads = conversion::encoder_to_rads(encoder, self.foc.ppr.unwrap())*self.foc.brushless_motor_config.gearbox_ratio();
+        let rads = conversion::encoder_to_rad(
+            encoder, 
+            self.foc.ppr.unwrap()
+        );
         Ok([rads])
     }
     /// Get the current velocity of the motors (in radians per second)
@@ -345,9 +357,12 @@ where
 	    foc.
 	    tmc4671_get_actual_velocity()
 	    .map_err(IOError::SpiError)?;
-	Ok([vel as f32]) //Should be rpm
-
+        let vel_rads = conversion::rpm_to_rads(
+            (vel as f32)/self.foc.brushless_motor_config.mech_to_elec()
+        );
+        Ok([vel_rads as f32]) 
     }
+
     /// Get the current torque of the motors (in Nm)
     fn get_current_torque(&mut self) -> Result<[f32; 1], IOError> {
 	let torque=self.
@@ -364,53 +379,65 @@ where
 	    foc.
 	    tmc4671_get_target_position()
 	    .map_err(IOError::SpiError)?;
-	Ok([conversion::encoder_to_rads(pos, self.foc.ppr.unwrap())*self.foc.brushless_motor_config.gearbox_ratio()])
-	// Ok([0.0])
-
+    	Ok([conversion::encoder_to_rad(
+            pos, 
+            self.foc.ppr.unwrap()
+        )])
     }
     /// Set the current target position of the motors output (in radians)
     fn set_target_position(&mut self, position: [f32; 1]) -> Result<(), IOError> {
         self.foc
-            .tmc4671_set_target_position(conversion::rads_to_encoder(
+            .tmc4671_set_target_position(conversion::rad_to_encoder(
                 position[0],
-                self.foc.ppr.unwrap()/self.foc.brushless_motor_config.gearbox_ratio(),
+                self.foc.ppr.unwrap(),
             ))
             .map(|_| ())
             .map_err(IOError::SpiError)
     }
 
-    /// Set the current target position of the motors (in radians)
+    /// Set the current velocity feedforward (in radians per second)
     fn set_velocity_feedforward(&mut self, velocity: [f32; 1]) -> Result<(), IOError> {
+        let vel_rpm = conversion::rads_to_rpm(
+            velocity[0]*self.foc.brushless_motor_config.mech_to_elec()
+        );
         self.foc
-            .tmc4671_set_velocity_offset(velocity[0] as i32 )
+            .tmc4671_set_velocity_offset(vel_rpm as i32 )
             .map(|_| ())
             .map_err(IOError::SpiError)
     }
-    // get velocity feedforward
+    // get current velocity feedforward (in radians per second)
     fn get_velocity_feedforward(&mut self) -> Result<[f32; 1], IOError> {
         let vel=self.
-        foc.
-        tmc4671_get_velocity_offset()
-        .map_err(IOError::SpiError)?;
-        Ok([vel as f32]) //TODO convert to rad/s
+           foc.
+           tmc4671_get_velocity_offset()
+           .map_err(IOError::SpiError)?;
+        let vel_rads = conversion::rpm_to_rads(
+            (vel as f32)/self.foc.brushless_motor_config.mech_to_elec(),
+        );
+        Ok([vel_rads as f32]) 
     }
 
 
 
+    // get current target velocity (in radians per second)
     fn get_target_velocity(&mut self) -> Result<[f32; 1], IOError> {
         let vel=self.
 	    foc.
 	    tmc4671_get_target_velocity()
 	    .map_err(IOError::SpiError)?;
-	Ok([vel as f32]) //TODO convert to rad/s
-
-
+        let vel_rads = conversion::rpm_to_rads(
+            (vel as f32)/self.foc.brushless_motor_config.mech_to_elec(),
+        );
+        Ok([vel_rads as f32]) 
     }
-
+    // set new target velocity (in radians per second)
     fn set_target_velocity(&mut self, velocity: [f32; 1]) -> Result<(), IOError> {
+        let vel_rpm = conversion::rads_to_rpm(
+            velocity[0]*self.foc.brushless_motor_config.mech_to_elec()
+        );
         self.foc
             .tmc4671_set_target_velocity(
-                velocity[0] as i32) // TODO convert to rpm
+                vel_rpm as i32) 
             .map(|_| ())
             .map_err(IOError::SpiError)
     }
@@ -422,8 +449,6 @@ where
 	    tmc4671_get_target_torque()
 	    .map_err(IOError::SpiError)?;
 	Ok([pos as f32])
-
-
     }
 
     fn set_target_torque(&mut self, torque: [f32; 1]) -> Result<(), IOError> {
@@ -471,16 +496,22 @@ where
 
 
     /// Get the velocity limit of the motors (in radians per second)
-    fn get_velocity_limit(&mut self) -> Result<[u32; 1], IOError> {
+    fn get_velocity_limit(&mut self) -> Result<[f32; 1], IOError> {
 	//TODO Conversion. Is it in rpm?
         let limit=self.foc.tmc4671_get_velocity_limit()
             .map_err(IOError::SpiError)?;
-	Ok([limit as u32])
+        // limit in rad/s
+        Ok([conversion::rpm_to_rads(
+            (limit as f32)/self.foc.brushless_motor_config.mech_to_elec()
+        )])
 
     }
     /// Set the velocity limit of the motors (in radians per second)
-    fn set_velocity_limit(&mut self, limit: [u32; 1]) -> Result<(), IOError> {
-	self.foc.tmc4671_set_velocity_limit(limit[0] as u32)
+    fn set_velocity_limit(&mut self, limit: [f32; 1]) -> Result<(), IOError> {
+        let limit_rpm = conversion::rads_to_rpm(
+            limit[0]*self.foc.brushless_motor_config.mech_to_elec()
+        );
+	self.foc.tmc4671_set_velocity_limit(limit_rpm as u32)
 			.map(|_| ())
 			.map_err(IOError::SpiError)
 
@@ -646,7 +677,7 @@ where
 	    error!("GET POS error: {:?}",e);
 	    0
 	});
-	let rads = conversion::encoder_to_rads(pos, self.foc.ppr.unwrap())*self.foc.brushless_motor_config.gearbox_ratio();//*self.foc.brushless_motor_config.axis_ratio();
+	let rads = conversion::encoder_to_rad(pos, self.foc.ppr.unwrap())*self.foc.brushless_motor_config.gearbox_ratio();//*self.foc.brushless_motor_config.axis_ratio();
 	let start_indices=compute_idx(d);
 	debug!("Start indices: {:?} start pos: {:?}",start_indices, rads.to_degrees());
 
@@ -674,7 +705,7 @@ where
 	    error!("GET POS error: {:?}",e);
 	    0
 	});
-	let rads2 = conversion::encoder_to_rads(pos, self.foc.ppr.unwrap())*self.foc.brushless_motor_config.gearbox_ratio();//*self.foc.brushless_motor_config.axis_ratio();
+	let rads2 = conversion::encoder_to_rad(pos, self.foc.ppr.unwrap())*self.foc.brushless_motor_config.gearbox_ratio();//*self.foc.brushless_motor_config.axis_ratio();
 
 
 
@@ -911,7 +942,7 @@ impl<'d> RawMotorsIO<1> for VentouseKind<'d> {
 
 
     /// Get the velocity limit of the motors (in radians per second)
-    fn get_velocity_limit(&mut self) -> Result<[u32; 1], IOError> {
+    fn get_velocity_limit(&mut self) -> Result<[f32; 1], IOError> {
         match self {
             VentouseKind::A(va) => va.get_velocity_limit(),
             VentouseKind::B(vb) => vb.get_velocity_limit(),
@@ -919,7 +950,7 @@ impl<'d> RawMotorsIO<1> for VentouseKind<'d> {
         }
     }
     /// Set the velocity limit of the motors (in radians per second)
-    fn set_velocity_limit(&mut self, velocity: [u32; 1]) -> Result<(), IOError> {
+    fn set_velocity_limit(&mut self, velocity: [f32; 1]) -> Result<(), IOError> {
         match self {
             VentouseKind::A(va) => va.set_velocity_limit(velocity),
             VentouseKind::B(vb) => vb.set_velocity_limit(velocity),
@@ -1085,10 +1116,19 @@ impl<'d> RawMotorsIO<1> for VentouseKind<'d> {
 }
 
 mod conversion {
-    pub fn encoder_to_rads(enc: i32, ppr: f32) -> f32 {
-        enc as f32 / ppr
+    // functions to convert encoder values to radians and vice versa
+    pub fn encoder_to_rad(enc: i32, ppr: f32) -> f32 {
+        enc as f32 / ppr  * 6.28318530718 // 2*pi = 6.28
     }
-    pub fn rads_to_encoder(rads: f32, ppr: f32) -> i32 {
-        (rads * ppr) as i32
+    pub fn rad_to_encoder(rads: f32, ppr: f32) -> i32 {
+        (rads * ppr / 6.28318530718) as i32 // 2*pi = 6.28
     }
+    // functions to convert from rpm to radians per second and vice versa
+    pub fn rpm_to_rads(rpm: f32) -> f32 {
+        rpm * 0.10471975512 // 2*pi/60 = 0.1047
+    }
+    pub fn rads_to_rpm(rads: f32) -> f32 {
+        rads * 9.54929658551 // 60/2*pi = 9.549
+    }
+
 }

--- a/src/motor_control/ventouse.rs
+++ b/src/motor_control/ventouse.rs
@@ -320,7 +320,7 @@ where
 	self
             .foc
             .tmc4671_set_actual_position(conversion::rad_to_encoder(
-                self.foc.brushless_motor_config.mech_gearbox_to_elec(pos[0]), // mechanical to electrical angle
+                self.foc.brushless_motor_config.angle_mech_to_elec(pos[0]), // mechanical to electrical angle
                 self.foc.ppr)
             ).map_err(IOError::SpiError)?;
 	Ok(())
@@ -333,7 +333,7 @@ where
             .foc
             .tmc4671_get_actual_position()
             .map_err(IOError::SpiError)?;
-        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox( // electrical to mechanical angle
+        Ok([self.foc.brushless_motor_config.angle_elec_to_mech( // electrical to mechanical angle
                 conversion::encoder_to_rad(
                         encoder, 
                         self.foc.ppr
@@ -346,7 +346,7 @@ where
 	    foc.
 	    tmc4671_get_actual_velocity()
 	    .map_err(IOError::SpiError)?;
-        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox(
+        Ok([self.foc.brushless_motor_config.angle_elec_to_mech(
                 conversion::rpm_to_rads(vel as f32)
         )]) 
     }
@@ -368,7 +368,7 @@ where
 	    foc.
 	    tmc4671_get_target_position()
 	    .map_err(IOError::SpiError)?;
-    	Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox( // electrical to mechanical position
+    	Ok([self.foc.brushless_motor_config.angle_elec_to_mech( // electrical to mechanical position
                 conversion::encoder_to_rad(
                         pos, 
                         self.foc.ppr
@@ -379,7 +379,7 @@ where
     fn set_target_position(&mut self, position: [f32; 1]) -> Result<(), IOError> {
         self.foc
             .tmc4671_set_target_position(conversion::rad_to_encoder(
-                self.foc.brushless_motor_config.mech_gearbox_to_elec(position[0]), // mechanical to electrical angle
+                self.foc.brushless_motor_config.angle_mech_to_elec(position[0]), // mechanical to electrical angle
                 self.foc.ppr)
             )
             .map(|_| ())
@@ -388,7 +388,7 @@ where
 
     /// Set the current velocity feedforward (in radians per second)
     fn set_velocity_feedforward(&mut self, velocity: [f32; 1]) -> Result<(), IOError> {
-        let vel_rpm =self.foc.brushless_motor_config.mech_gearbox_to_elec(
+        let vel_rpm =self.foc.brushless_motor_config.angle_mech_to_elec(
                 conversion::rads_to_rpm(velocity[0] as f32)
             );
         self.foc
@@ -402,7 +402,7 @@ where
            foc.
            tmc4671_get_velocity_offset()
            .map_err(IOError::SpiError)?;
-        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox(
+        Ok([self.foc.brushless_motor_config.angle_elec_to_mech(
                 conversion::rpm_to_rads(vel as f32)
         )]) 
     }
@@ -416,13 +416,13 @@ where
 	    tmc4671_get_target_velocity()
 	    .map_err(IOError::SpiError)?;
         
-        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox(
+        Ok([self.foc.brushless_motor_config.angle_elec_to_mech(
             conversion::rpm_to_rads(vel as f32)
         )]) 
     }
     // set new target velocity (in radians per second)
     fn set_target_velocity(&mut self, velocity: [f32; 1]) -> Result<(), IOError> {
-        let vel_rpm = self.foc.brushless_motor_config.mech_gearbox_to_elec(
+        let vel_rpm = self.foc.brushless_motor_config.angle_mech_to_elec(
                 conversion::rads_to_rpm(velocity[0] as f32)
             );
         self.foc
@@ -494,14 +494,14 @@ where
         let limit=self.foc.tmc4671_get_velocity_limit()
             .map_err(IOError::SpiError)?;
         // limit in rad/s
-        Ok([self.foc.brushless_motor_config.elec_to_mech_gearbox(
+        Ok([self.foc.brushless_motor_config.angle_elec_to_mech(
                 conversion::rpm_to_rads(limit as f32)
             )]) 
 
     }
     /// Set the velocity limit of the motors (in radians per second)
     fn set_velocity_limit(&mut self, limit: [f32; 1]) -> Result<(), IOError> {
-        let limit_rpm = self.foc.brushless_motor_config.mech_gearbox_to_elec(
+        let limit_rpm = self.foc.brushless_motor_config.angle_mech_to_elec(
                 conversion::rads_to_rpm(limit[0] as f32)
             );
 	self.foc.tmc4671_set_velocity_limit(limit_rpm as u32)
@@ -670,7 +670,7 @@ where
 	    error!("GET POS error: {:?}",e);
 	    0
 	});
-	let rads = self.foc.brushless_motor_config.elec_to_mech_gearbox(conversion::encoder_to_rad(pos, self.foc.ppr));
+	let rads = self.foc.brushless_motor_config.angle_elec_to_mech(conversion::encoder_to_rad(pos, self.foc.ppr));
 	let start_indices=compute_idx(d);
 	debug!("Start indices: {:?} start pos: {:?}",start_indices, rads.to_degrees());
 
@@ -698,7 +698,7 @@ where
 	    error!("GET POS error: {:?}",e);
 	    0
 	});
-	let rads2 = self.foc.brushless_motor_config.elec_to_mech_gearbox(conversion::encoder_to_rad(pos, self.foc.ppr));
+	let rads2 = self.foc.brushless_motor_config.angle_elec_to_mech(conversion::encoder_to_rad(pos, self.foc.ppr));
 
 
 

--- a/src/shared_memory.rs
+++ b/src/shared_memory.rs
@@ -25,7 +25,7 @@ pub struct Memory<const N: usize> {
     position_pid_gains: [Pid;N],
 
     uq_ud_limit: [i16;N],
-    torque_flux_limit: [u16;N],
+    torque_flux_limit: [f32;N],
     velocity_limit: [f32;N],
 
 
@@ -180,10 +180,10 @@ impl<const N: usize> SharedMemory<N> {
 	self.inner.borrow_mut().uq_ud_limit=limit;
     }
 
-    pub fn get_torque_flux_limit(&self) -> [u16;N] {
+    pub fn get_torque_flux_limit(&self) -> [f32;N] {
 	self.inner.borrow().torque_flux_limit
     }
-    pub fn set_torque_flux_limit(&self, limit: [u16;N]) {
+    pub fn set_torque_flux_limit(&self, limit: [f32;N]) {
 	self.inner.borrow_mut().torque_flux_limit=limit;
     }
 
@@ -249,7 +249,7 @@ impl<const N: usize> SharedMemory<N> {
 		position_pid_gains: [Pid{p:0,i:0};N],
 
 		uq_ud_limit: [0;N],
-		torque_flux_limit: [0;N],
+		torque_flux_limit: [0.0;N],
 		velocity_limit: [0.0;N],
                 velocity_feedforward: [0.0; N],
 
@@ -283,7 +283,7 @@ impl<const N: usize> SharedMemory<N> {
 	    // torque_flux_limit: actuator.get_torque_flux_limit().unwrap_or([f32::NAN;N]),
 	    // velocity_limit: actuator.get_velocity_limit().unwrap_or([f32::NAN;N]),
 	    uq_ud_limit: actuator.get_uq_ud_limit().unwrap_or([0;N]),
-	    torque_flux_limit: actuator.get_torque_flux_limit().unwrap_or([0;N]),
+	    torque_flux_limit: actuator.get_torque_flux_limit().unwrap_or([0.0;N]),
 	    velocity_limit: actuator.get_velocity_limit().unwrap_or([0.0;N]),
             velocity_feedforward: actuator.get_velocity_feedforward().unwrap_or([0.0; N]),
 

--- a/src/shared_memory.rs
+++ b/src/shared_memory.rs
@@ -26,7 +26,7 @@ pub struct Memory<const N: usize> {
 
     uq_ud_limit: [i16;N],
     torque_flux_limit: [u16;N],
-    velocity_limit: [u32;N],
+    velocity_limit: [f32;N],
 
 
     axis_sensor: [f32; N],
@@ -187,10 +187,10 @@ impl<const N: usize> SharedMemory<N> {
 	self.inner.borrow_mut().torque_flux_limit=limit;
     }
 
-    pub fn get_velocity_limit(&self) -> [u32;N] {
+    pub fn get_velocity_limit(&self) -> [f32;N] {
 	self.inner.borrow().velocity_limit
     }
-    pub fn set_velocity_limit(&self, limit: [u32;N]) {
+    pub fn set_velocity_limit(&self, limit: [f32;N]) {
 	self.inner.borrow_mut().velocity_limit=limit;
     }
 
@@ -250,8 +250,8 @@ impl<const N: usize> SharedMemory<N> {
 
 		uq_ud_limit: [0;N],
 		torque_flux_limit: [0;N],
-		velocity_limit: [0;N],
-        velocity_feedforward: [0.0; N],
+		velocity_limit: [0.0;N],
+                velocity_feedforward: [0.0; N],
 
 
 		error_led: false,
@@ -284,8 +284,8 @@ impl<const N: usize> SharedMemory<N> {
 	    // velocity_limit: actuator.get_velocity_limit().unwrap_or([f32::NAN;N]),
 	    uq_ud_limit: actuator.get_uq_ud_limit().unwrap_or([0;N]),
 	    torque_flux_limit: actuator.get_torque_flux_limit().unwrap_or([0;N]),
-	    velocity_limit: actuator.get_velocity_limit().unwrap_or([0;N]),
-        velocity_feedforward: actuator.get_velocity_feedforward().unwrap_or([0.0; N]),
+	    velocity_limit: actuator.get_velocity_limit().unwrap_or([0.0;N]),
+            velocity_feedforward: actuator.get_velocity_feedforward().unwrap_or([0.0; N]),
 
 	    #[cfg(feature = "orbita3d")]
 	    index_sensor: actuator.get_index_sensor(),


### PR DESCRIPTION
Ok so this is the PR in which the units have been unified:
 - velocity is in radians per second
 - position is in radians
 - torque is in milliAmps
The only one which is left unchanged is the uq_ud_limit which is in 15 bit PWM duty cycle 0-32767. We could set it in voltage but I am aftraid that we will just make things harder to figure out. This way we just put these limits at 32767 and we have the full power available. (or maybe a bit lower than that to be sure that the currents are measured directly).

Additional change of this PR is that it allows to control the motor angle and velocity at the motor shaft, after the gearbox or after the axis recution. 
In order to decide where to control the motor, set the parameter in `Cargo.toml` 
- `gearbox_output` - for controlling the motor angle after the gearbox
- `axis_output` - for controlling the motor angle after the gearbox and the axis reduciton
- neihter of those - for controlling the motor angle at the motor shaft (begore the gearbox)



