### PR TITLE
ADC offset calibration on every start

### DIFF
--- a/src/motor_control/foc.rs
+++ b/src/motor_control/foc.rs
@@ -64,6 +64,7 @@ pub const UQ_UD_EXT: u32 = 0x000001000; // Openloop "torque_target" 2000
 pub enum Tmc4671Registers {
     CHIPINFO_DATA = 0x00,
     CHIPINFO_ADDR = 0x01,
+    ADC_RAW_DATA = 0x02,
     ADC_RAW_ADDR = 0x03,
     dsADC_MCFG_B_MCFG_A = 0x04,
     dsADC_MCLK_A = 0x05,
@@ -276,6 +277,14 @@ where
         self.tmc4671_write_register(Tmc4671Registers::MODE_RAMP_MODE_MOTION as u8, data)
     }
 
+
+    
+    pub fn tmc4671_get_adc_raw(&mut self) -> Result<(u16,u16), embassy_stm32::spi::Error> {
+        match self.tmc4671_get_u32(Tmc4671Registers::ADC_RAW_DATA as u8){
+            Ok(raw) => Ok(((raw & 0xFFFF) as u16, (raw  >> 16) as u16)),
+            Err(e) => Err(e)
+        }
+    }
 
     pub fn tmc4671_get_pid_flux(&mut self) -> Result<u32, embassy_stm32::spi::Error> {
 	self.tmc4671_get_u32(Tmc4671Registers::PID_FLUX_P_FLUX_I as u8)

--- a/src/motor_control/ventouse.rs
+++ b/src/motor_control/ventouse.rs
@@ -102,6 +102,18 @@ where
 
 	}
 
+    match self.calibrate_adc_offsets().await
+	{
+	    Ok(_) => info!("[Ventouse{:?}] ADC offset calibration done", self.kind),
+	    Err(e) => {
+		ret_err=true;
+		error!("[Ventouse{:?}] ADC offset calibration failed: {:?}  => check SPI and power connection", self.kind,e);
+		err=IOError::SpiError(e);
+
+	    }
+
+	}
+
         match self.align_motor().await
 	{
 	    Ok(_) => info!("[Ventouse{:?}] align done",self.kind),
@@ -130,6 +142,34 @@ where
 	}
         Ok(())
     }
+
+
+    pub async fn calibrate_adc_offsets(&mut self) -> Result<(), embassy_stm32::spi::Error> {
+   
+        // stop the motor
+        // disable potential motion/torque control
+        self.foc.tmc4671_set_mode(MotionMode::Stopped)?;
+
+        // read the adc raw values for finding the current offset (1000 times)
+        let mut adc_offset: [u32; 2] = [0; 2];
+        for _ in 0..1000 {
+            self.foc.tmc4671_get_adc_raw().map(|adc| {
+                adc_offset[0] += adc.0 as u32;
+                adc_offset[1] += adc.1 as u32;
+            })?;
+        }
+        // divide by 1000 to get the average
+        adc_offset[0] /= 1000;
+        adc_offset[1] /= 1000;
+
+        // set the new offset values
+        self.foc.current_sensing_config.set_adc_offsets(adc_offset[0], adc_offset[1]);
+        self.foc.tmc4671_checked_write(Tmc4671Registers::ADC_I0_SCALE_OFFSET as u8, self.foc.current_sensing_config.adc_i0_scale_offset())?;
+        self.foc.tmc4671_checked_write(Tmc4671Registers::ADC_I1_SCALE_OFFSET as u8, self.foc.current_sensing_config.adc_i1_scale_offset())?;
+        
+        Ok(())
+    }
+
 
     pub async fn align_motor(&mut self) -> Result<(), embassy_stm32::spi::Error> {
         // /!\ Please note that the TMC6200 must be in Single-line mode (aka 6-PMW)


### PR DESCRIPTION
Initial implementation of ADC offset finidng 
- takes an average of 1000 reads of the ADC with motion/torque control disabled

**1000 is an arbitraty number and can be changed to a bigger or a lower one. In my setup this calibration lasts for **36ms.**** 

I've tested the approach in TMCL and using the `pytrinamic` package. In my case it works well and finds slightly different offsets for each one of my boards/motors.  And it seems to be very repeatable: running the code several times results in very similar offsets:

Here is the data for 5 runs of the hardware

run | VentouseB ADC0 offset | VentouseB ADC1 offset | VentouseC ADC0 offset | VentouseC ADC1 offset 
--- | --- | --- | --- | --- 
1 | 33157 | 33295  | 33232 | 33153
2 |33155 |33293  | 33231| 33150
3 | 33155| 33293  | 33231| 33150
4 | 33155| 33293  | 33232| 33152 
5 | 33156 | 33294 | 33232 | 33154

This code no longer uses the default values of the adc offsets in the `CurrentSensing`: https://github.com/pollen-robotics/firmware_Poulpe/blob/77c168b9af8e402f3661babf678315a5c92f7d4e/src/config/current_sense.rs#L29-L34

This code could potentially be wrapped in a `#[cfg(adc_auto_calibration)]` or something like that to make it optional. For the moment I did not do it. 