### PR TITLE
No torque off in the init for orbita2d - some small robustness updates + bugfixes

### DIFF
--- a/src/motor_control/foc.rs
+++ b/src/motor_control/foc.rs
@@ -338,7 +338,15 @@ where
 
         match t{
             t if t.is_nan() => Err(IOError::InvalidData),
-            _ => Ok((t as f32) - 273.15) // final conversion to Celsius
+            _ => {
+                let mut t_celsius = (t as f32) - 273.15;
+                // a seemingly constant linear error
+                // empirically tested correction
+                t_celsius = ( t_celsius - 1.75297 ) / 1.0987;
+                Ok(t_celsius) // final conversion to Celsius
+
+            }
+            
         }
     }
 
@@ -363,6 +371,9 @@ where
                 let adc_raw = (raw & 0xffff) as f32; // extract the raw value
                 let mut voltage = (adc_raw - self.adc_vm_offset)/32768.0 * 2.5; // scale to 0-2.5V
                 voltage = voltage * 48.0; // 47k/1k voltage divider
+                // a seemingly constant linear error 
+                // empirically tested correction
+                voltage = ( voltage - 0.8580 ) / 1.0285; 
                 Ok(voltage) 
             }
             Err(e) => Err(e),

--- a/src/motor_control/task.rs
+++ b/src/motor_control/task.rs
@@ -345,18 +345,29 @@ pub async fn control_loop(config: ActuatorConfig) {
         }
 
         // read the axis sensors - but disable the torque to avoid the noise
-        #[cfg(feature = "orbita2d")]
-        actuator.set_torque([false, false]).unwrap(); //FIXME: axis sensors are too noisy when torque is on
         #[cfg(feature = "orbita3d")]
         actuator.set_torque([false, false, false]).unwrap(); //FIXME: axis sensors are too noisy when torque is on
                                                             // #[cfg(feature = "orbita2d")]
         Timer::after(Duration::from_micros(100000)).await;
 
-        let init_sensors = actuator.get_axis_sensors().unwrap();
+        // read the axis sensors
+        let mut init_sensors = [0.0; config::N_AXIS];
+        match actuator.get_axis_sensors(){
+            Ok(sensors) => {
+                init_sensors = sensors;
+            }
+            Err(e) => {
+                error!("Error reading axis sensors: {:?}", e);
+                init_error = BoardStatus::SensorError;
+                continue ; //  retry the init if there is an error
+
+            }
+        }
+        debug!("init sensors: {:?}", init_sensors);
+        
+
         // #[cfg(feature = "orbita2d")]
         Timer::after(Duration::from_micros(100000)).await;
-        #[cfg(feature = "orbita2d")]
-        actuator.set_torque([true, true]).unwrap();
         #[cfg(feature = "orbita3d")]
         actuator.set_torque([true, true, true]).unwrap();
 
@@ -373,20 +384,35 @@ pub async fn control_loop(config: ActuatorConfig) {
         
 
         // read the sensors - but disable the torque to avoid the noise
-        #[cfg(feature = "orbita2d")]
-        actuator.set_torque([false, false]).unwrap(); //FIXME: axis sensors are too noisy when torque is on
         #[cfg(feature = "orbita3d")]
         actuator.set_torque([false, false, false]).unwrap(); //FIXME: axis sensors are too noisy when torque is on
 
         Timer::after(Duration::from_micros(100000)).await;
 
-        let moved_sensors = actuator.get_axis_sensors().unwrap();
+
+
+        // read the axis sensors
+        let mut moved_sensors = [0.0; config::N_AXIS];
+        match actuator.get_axis_sensors(){
+            Ok(sensors) => {
+                moved_sensors = sensors;
+            }
+            Err(e) => {
+                error!("Error reading axis sensors: {:?}", e);
+                init_error = BoardStatus::SensorError;
+                continue ; //  retry the init if there is an error
+
+            }
+        }
+        debug!("moved sensors: {:?}", moved_sensors);
+        
+
         SHARED_MEMORY.lock().await.set_axis_sensor(moved_sensors);
 
         Timer::after(Duration::from_micros(100000)).await;
         // enable torques
-        #[cfg(feature = "orbita2d")]
-        actuator.set_torque([true, true]).unwrap();
+        // #[cfg(feature = "orbita2d")]
+        // actuator.set_torque([true, true]).unwrap();
         #[cfg(feature = "orbita3d")]
         actuator.set_torque([true, true, true]).unwrap();
 
@@ -408,9 +434,14 @@ pub async fn control_loop(config: ActuatorConfig) {
         {
             for (i, s) in moved_sensors.iter().enumerate() {
                 diff[i] = *s - init_sensors[i];
+                // if motor moved acors 0 the diff will be bigger around 2PI - diff
                 if diff[i] > 3.141592 {
                     diff[i] = diff[i] - 2.0 * 3.141592;
+                }else if diff[i] < -3.141592 {
+                    diff[i] = diff[i] + 2.0 * 3.141592;
                 }
+
+                debug!("diff: {:?}", diff[i]);
 
                 if (diff[i] <= 0.0 && diff[i] > -0.08) || (diff[i] > 0.0 || diff[i].is_nan()) {
                     error!(
@@ -425,33 +456,31 @@ pub async fn control_loop(config: ActuatorConfig) {
         {
             for (i, s) in moved_sensors.iter().enumerate() {
                 diff[i] = *s - init_sensors[i];
+                // if motor moved acors 0 the diff will be bigger around 2PI-diff
                 if diff[i] > 3.141592 {
                     diff[i] = diff[i] - 2.0 * 3.141592;
+                }else if diff[i] < -3.141592 {
+                    diff[i] = diff[i] + 2.0 * 3.141592;
                 }
 
-                // //WTF? We cannot use abs() for f32?
-                // let absdiff: f32 = if diff[i].is_sign_positive() {
-                //     diff[i]
-                // } else {
-                //     -diff[i]
-                // };
+                debug!("diff: {:?}", diff[i]);
 
                 if i == 0 {
-                    if (diff[i] > -0.1) || diff[i].is_nan() {
+                    if (diff[i] > -0.09) || (diff[i] < -0.2) || diff[i].is_nan() { // it should move ~0.15 rad
                         error!(
                             "Axis sensor {:?} moved too little: {:?} Check sensor connection??",
                             i, diff[i]
                         );
-                        init_error = BoardStatus::SensorError;
+                        // init_error = BoardStatus::SensorError;
                     }
                 }
                 if i == 1 {
-                    if (diff[i] < 0.05) || diff[i].is_nan() {
+                    if (diff[i] < 0.04) || (diff[i] > 0.07) || diff[i].is_nan() { // it should move ~0.05 rad
                         error!(
                             "Axis sensor {:?} moved too little: {:?} Check sensor connection??",
                             i, diff[i]
                         );
-                        init_error = BoardStatus::SensorError;
+                        // init_error = BoardStatus::SensorError;
                     }
                 }
             }


### PR DESCRIPTION
Two small changes:

1) For orbita2d the motors are not turned off in the init procedure to read the axis sensors. 
    - In my experiments this was not necessary (never had an error)
    - The experiments showed that this is error prone as the arm can rise (shoulder lifts the arm) and in that case the due to the gravity the arm can drop a bit as no torques are applied and produce an error in the initialisation
    - Keeping the torques on allows for initialisation in the higher range of inital positions (not just streched downwards)
 
 2) A bugfix when calculating the expected angle of the orbita2d to cover during init 
 3) A bugfix of calculating the distance between the initial and moved position of the axis sensors in the init
    - had issues if the sensor passes over the 2pi 