### PR TITLE
Feat panic dynamixel remove

### DIFF
--- a/src/dynamixel/conversion.rs
+++ b/src/dynamixel/conversion.rs
@@ -1,12 +1,23 @@
+use defmt::{error};
+use defmt::Format;
+
+#[derive(Format)]
+pub enum ConversionError {
+    InvalidDataLength,
+}
+
 use crate::motor_control::Pid;
 
-pub fn bytes_to_bool<const N: usize>(data: &[u8]) -> [bool; N] {
-    assert!(data.len() == N);
+pub fn bytes_to_bool<const N: usize>(data: &[u8]) -> Result<[bool; N], ConversionError> {
+    if data.len() != N {
+        error!("InvalidDataLength, received: {} instead of {}", data.len(), N);
+        return Err(ConversionError::InvalidDataLength);
+    }
     let mut result = [false; N];
     for i in 0..N {
         result[i] = data[i] != 0;
     }
-    result
+    Ok(result)
 }
 
 pub fn bool_to_bytes<const N: usize>(data: [bool; N]) -> [u8; N] {
@@ -19,13 +30,17 @@ pub fn bool_to_bytes<const N: usize>(data: [bool; N]) -> [u8; N] {
     result
 }
 
-pub fn bytes_to_float<const N: usize>(data: &[u8]) -> [f32; N] {
-    assert!(data.len() == N * 4);
+pub fn bytes_to_float<const N: usize>(data: &[u8]) -> Result<[f32; N], ConversionError> {
+    if data.len() != (N * 4) {
+        error!("InvalidDataLength, received: {} instead of {}", data.len(), N * 4);
+        return Err(ConversionError::InvalidDataLength);
+    }
+
     let mut result = [0.0; N];
     for i in 0..N {
         result[i] = f32::from_le_bytes(data[i * 4..(i + 1) * 4].try_into().unwrap());
     }
-    result
+    Ok(result)
 }
 
 pub fn float_to_bytes<const N: usize>(data: [f32; N]) -> [u8; 4 * N] {
@@ -48,13 +63,16 @@ pub fn u32_to_bytes<const N: usize>(data: [u32; N]) -> [u8; 4 * N] {
     result
 }
 
-pub fn bytes_to_u32<const N: usize>(data: &[u8]) -> [u32; N] {
-    assert!(data.len() == N * 4);
+pub fn bytes_to_u32<const N: usize>(data: &[u8]) -> Result<[u32; N], ConversionError> {
+    if data.len() != ( N * 4) {
+        error!("InvalidDataLength, received: {} instead of {}", data.len(), N * 4);
+        return Err(ConversionError::InvalidDataLength);
+    }
     let mut result = [0; N];
     for i in 0..N {
         result[i] = u32::from_le_bytes(data[i * 4..(i + 1) * 4].try_into().unwrap());
     }
-    result
+    Ok(result)
 }
 
 pub fn u16_to_bytes<const N: usize>(data: [u16; N]) -> [u8; 2 * N] {
@@ -67,13 +85,18 @@ pub fn u16_to_bytes<const N: usize>(data: [u16; N]) -> [u8; 2 * N] {
     result
 }
 
-pub fn bytes_to_u16<const N: usize>(data: &[u8]) -> [u16; N] {
-    assert!(data.len() == N * 2);
+pub fn bytes_to_u16<const N: usize>(data: &[u8]) -> Result<[u16; N], ConversionError> {
+    if data.len() != ( N * 2) {
+        error!("InvalidDataLength, received: {} instead of {}", data.len(), N * 2);
+        return Err(ConversionError::InvalidDataLength);
+    }
+
     let mut result = [0; N];
     for i in 0..N {
         result[i] = u16::from_le_bytes(data[i * 2..(i + 1) * 2].try_into().unwrap());
     }
-    result
+    
+    Ok(result)
 }
 
 pub fn i16_to_bytes<const N: usize>(data: [i16; N]) -> [u8; 2 * N] {
@@ -86,13 +109,17 @@ pub fn i16_to_bytes<const N: usize>(data: [i16; N]) -> [u8; 2 * N] {
     result
 }
 
-pub fn bytes_to_i16<const N: usize>(data: &[u8]) -> [i16; N] {
-    assert!(data.len() == N * 2);
+pub fn bytes_to_i16<const N: usize>(data: &[u8]) -> Result<[i16; N], ConversionError> {
+    if data.len() != ( N * 2) {
+        error!("InvalidDataLength, received: {} instead of {}", data.len(), N * 2);
+        return Err(ConversionError::InvalidDataLength);
+    }
+
     let mut result = [0; N];
     for i in 0..N {
         result[i] = i16::from_le_bytes(data[i * 2..(i + 1) * 2].try_into().unwrap());
     }
-    result
+    Ok(result)
 }
 
 pub fn pid_to_bytes<const N: usize>(pid: [Pid; N]) -> [u8; 4 * N] {
@@ -104,8 +131,12 @@ pub fn pid_to_bytes<const N: usize>(pid: [Pid; N]) -> [u8; 4 * N] {
     result
 }
 
-pub fn bytes_to_pid<const N: usize>(data: &[u8]) -> [Pid; N] {
-    assert!(data.len() == N * 4); //FIXME: remove assert!!
+pub fn bytes_to_pid<const N: usize>(data: &[u8]) -> Result<[Pid; N], ConversionError> {
+    if data.len() != ( N * 4) {
+        error!("InvalidDataLength, received: {} instead of {}", data.len(), N * 4);
+        return Err(ConversionError::InvalidDataLength);
+    }
+    
     let mut result = [Pid { p: 0, i: 0 }; N];
 
     for i in 0..N {
@@ -117,5 +148,5 @@ pub fn bytes_to_pid<const N: usize>(data: &[u8]) -> [Pid; N] {
 
         result[i] = pid;
     }
-    result
+    Ok(result)
 }

--- a/src/dynamixel/task.rs
+++ b/src/dynamixel/task.rs
@@ -314,283 +314,345 @@ pub async fn messsage_handler(usart: config::DynamixelUart, dir_pin: AnyPin) {
                             }
 
                             DynamixelRegister::TorqueEnable => {
-                                let torque_on: [bool; config::N_AXIS] =
-                                    conversion::bytes_to_bool(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_torque_on(torque_on);
-                                }
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_bool(write_data_packet.data) {
+                                    Ok(torque_on) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_torque_on(torque_on);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::FluxPID => {
-                                let gains: [Pid; config::N_AXIS] =
-                                    conversion::bytes_to_pid(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_flux_pid_gains(gains);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_pid(write_data_packet.data) {
+                                    Ok(gains) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_flux_pid_gains(gains);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::TorquePID => {
-                                let gains: [Pid; config::N_AXIS] =
-                                    conversion::bytes_to_pid(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_torque_pid_gains(gains);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_pid(write_data_packet.data) {
+                                    Ok(gains) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_torque_pid_gains(gains);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::VelocityPID => {
-                                let gains: [Pid; config::N_AXIS] =
-                                    conversion::bytes_to_pid(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_velocity_pid_gains(gains);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_pid(write_data_packet.data) {
+                                    Ok(gains) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_velocity_pid_gains(gains);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::PositionPID => {
-                                let gains: [Pid; config::N_AXIS] =
-                                    conversion::bytes_to_pid(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_position_pid_gains(gains);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_pid(write_data_packet.data) {
+                                    Ok(gains) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_position_pid_gains(gains);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::UqUdLimit => {
-                                let limits: [i16; config::N_AXIS] =
-                                    conversion::bytes_to_i16(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_uq_ud_limit(limits);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_i16(write_data_packet.data) {
+                                    Ok(limits) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_uq_ud_limit(limits);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::TorqueFluxLimit => {
-                                let limits: [f32; config::N_AXIS] =
-                                    conversion::bytes_to_float(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_torque_flux_limit(limits);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_float(write_data_packet.data) {
+                                    Ok(limits) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_torque_flux_limit(limits);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::TorqueFluxLimitMax => {
-                                let limits: [f32; config::N_AXIS] =
-                                    conversion::bytes_to_float(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_torque_flux_limit_max(limits);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_float(write_data_packet.data) {
+                                    Ok(limits) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_torque_flux_limit_max(limits);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::VelocityLimit => {
-                                let limits: [f32; config::N_AXIS] =
-                                    conversion::bytes_to_float(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_velocity_limit(limits);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_float(write_data_packet.data) {
+                                    Ok(limits) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_velocity_limit(limits);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::VelocityLimitMax => {
-                                let limits: [f32; config::N_AXIS] =
-                                    conversion::bytes_to_float(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_velocity_limit_max(limits);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                match conversion::bytes_to_float(write_data_packet.data) {
+                                    Ok(limits) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_velocity_limit_max(limits);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
                             }
 
                             DynamixelRegister::FeedforwardVelocity => {
-                                let velocity_feedforward: [f32; config::N_AXIS] =
-                                    conversion::bytes_to_float(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY
-                                        .lock()
-                                        .await
-                                        .set_velocity_feedforward(velocity_feedforward);
-                                }
-
-                                let sp = StatusPacket::ack(id, dxl_error);
-                                debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
-                                }
-                            }
-
-                            DynamixelRegister::TargetPosition => {
-                                let target: [f32; config::N_AXIS] =
-                                    conversion::bytes_to_float(write_data_packet.data);
-                                {
-                                    SHARED_MEMORY.lock().await.set_target_position(target);
-                                }
-                                // set zero feedforward velocity
-                                {
-                                    SHARED_MEMORY
-                                        .lock()
-                                        .await
-                                        .set_velocity_feedforward([0.0; config::N_AXIS]);
-                                }
-
-                                //return the full state
-                                let value = { SHARED_MEMORY.lock().await.get_current_position() };
-                                // let value = { SHARED_MEMORY.lock().await.get_full_state() };
-                                let value = conversion::float_to_bytes(value);
-
-                                let sp = StatusPacket::with_value(id, dxl_error, value);
-                                trace!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
-                                }
-                            }
-                            // parse the target position and velocity feedforward message
-                            DynamixelRegister::TargetPositionWithVelocityFF => {
-                                // first the target position
-                                let target: [f32; config::N_AXIS] = conversion::bytes_to_float(
-                                    write_data_packet.data[0..4 * config::N_AXIS]
-                                        .try_into()
-                                        .unwrap(),
-                                );
-                                {
-                                    SHARED_MEMORY.lock().await.set_target_position(target);
-                                }
-
-                                // then the velocity feedforward
-                                let velocity_feedforward: [f32; config::N_AXIS] =
-                                    conversion::bytes_to_float(
-                                        write_data_packet.data
-                                            [4 * config::N_AXIS..8 * config::N_AXIS]
-                                            .try_into()
-                                            .unwrap(),
-                                    );
-                                {
-                                    SHARED_MEMORY
-                                        .lock()
-                                        .await
-                                        .set_velocity_feedforward(velocity_feedforward);
-                                }
-
-                                //return the full state
-                                let value = { SHARED_MEMORY.lock().await.get_full_state() };
-                                let value = conversion::float_to_bytes(value);
-
-                                let sp = StatusPacket::with_value(id, dxl_error, value);
-                                trace!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
-                                }
-                            }
-
-                            // parse the target position and velocity feedforward message
-                            DynamixelRegister::TargetPositionEstimateVelocityFF => {
-                                // save the old target position
-                                let old_target =
-                                    { SHARED_MEMORY.lock().await.get_target_position() };
-
-                                // first the target position
-                                let target: [f32; config::N_AXIS] = conversion::bytes_to_float(
-                                    write_data_packet.data[0..4 * config::N_AXIS]
-                                        .try_into()
-                                        .unwrap(),
-                                );
-
-                                // get the timestamp of the last target set - in order to calculate the velocity feedforward
-                                let target_set_timestamp =
-                                    { SHARED_MEMORY.lock().await.get_target_set_timestamp() };
-                                match target_set_timestamp {
-                                    Some(target_set_timestamp) => {
-                                        // calculate the velocity feedforward
-                                        let dt = target_set_timestamp.elapsed().as_micros() as f32
-                                            / 1_000_000.0;
-                                        let mut velocity_feedforward = [0.0; config::N_AXIS];
-                                        //vel = (target - old_target)/dt;
-                                        velocity_feedforward
-                                            .iter_mut()
-                                            .zip(target.iter().zip(old_target.iter()))
-                                            .for_each(|(v, (t, o))| {
-                                                *v = (*t - *o) / dt as f32;
-                                            });
+                                match conversion::bytes_to_float(write_data_packet.data) {
+                                    Ok(feedforward) => {
                                         {
                                             SHARED_MEMORY
                                                 .lock()
                                                 .await
-                                                .set_velocity_feedforward(velocity_feedforward);
+                                                .set_velocity_feedforward(feedforward);
+                                        }
+                                        let sp = StatusPacket::ack(id, dxl_error);
+                                        debug!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
                                         }
                                     }
-                                    None => {
-                                        // if there is no timestamp, set the velocity feedforward to zero
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
+                                }
+                            }
+
+                            DynamixelRegister::TargetPosition => {
+
+                                match conversion::bytes_to_float(write_data_packet.data) {
+                                    Ok(target) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_target_position(target);
+                                        }
+                                        // set zero feedforward velocity
                                         {
                                             SHARED_MEMORY
                                                 .lock()
                                                 .await
                                                 .set_velocity_feedforward([0.0; config::N_AXIS]);
                                         }
+
+                                        //return the full state
+                                        let value = { SHARED_MEMORY.lock().await.get_current_position() };
+                                        // let value = { SHARED_MEMORY.lock().await.get_full_state() };
+                                        let value = conversion::float_to_bytes(value);
+
+                                        let sp = StatusPacket::with_value(id, dxl_error, value);
+                                        trace!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
                                     }
                                 }
-                                // set the new target position - after the feedforward not to modify the target_set_timestamp
-                                {
-                                    SHARED_MEMORY.lock().await.set_target_position(target);
-                                }
+                            }
+                            // parse the target position and velocity feedforward message
+                            DynamixelRegister::TargetPositionWithVelocityFF => {
+                                
+                                let pos_data = &write_data_packet.data[0..4 * config::N_AXIS];
+                                let vel_data = &write_data_packet.data[4 * config::N_AXIS..8 * config::N_AXIS];
+                                // set the position target
+                                match conversion::bytes_to_float(pos_data){
+                                    Ok(target) => {
+                                        {
+                                            SHARED_MEMORY.lock().await.set_target_position(target);
+                                        }
+                                        // set the velocity feedforward 
+                                        // only if the position target is set
+                                        match conversion::bytes_to_float(vel_data){
+                                            Ok(velocity_feedforward) => {
+                                                {
+                                                    SHARED_MEMORY
+                                                        .lock()
+                                                        .await
+                                                        .set_velocity_feedforward(velocity_feedforward);
+                                                }
 
-                                //return the full state
-                                let value = { SHARED_MEMORY.lock().await.get_full_state() };
-                                let value = conversion::float_to_bytes(value);
-                                let sp = StatusPacket::with_value(id, dxl_error, value);
-                                trace!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
-                                if let Some(e) = dxl.write(&sp).await.err() {
-                                    error!("Error: {:?}", e);
+                                                //return the full state
+                                                let value = { SHARED_MEMORY.lock().await.get_current_position() };
+                                                // let value = { SHARED_MEMORY.lock().await.get_full_state() };
+                                                let value = conversion::float_to_bytes(value);
+
+                                                let sp = StatusPacket::with_value(id, dxl_error, value);
+                                                trace!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                                if let Some(e) = dxl.write(&sp).await.err() {
+                                                    error!("Error: {:?}", e);
+                                                }
+
+                                            }
+                                            Err(e) => {
+                                                error!("Error: {:?}", e);
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
                                 }
+                            }
+
+                            // parse the target position and velocity feedforward message
+                            DynamixelRegister::TargetPositionEstimateVelocityFF => {
+                                match conversion::bytes_to_float(write_data_packet.data){
+                                    Ok(target) => {
+                                        // save the old target position
+                                        let old_target = { SHARED_MEMORY.lock().await.get_target_position() };
+
+                                        // get the timestamp of the last target set 
+                                        // in order to calculate the velocity feedforward
+                                        match { SHARED_MEMORY.lock().await.get_target_set_timestamp() } {
+                                            Some(target_set_timestamp) => {
+                                                // calculate the time elapsed from the last target set
+                                                let dt = target_set_timestamp.elapsed().as_micros() as f32
+                                                    / 1_000_000.0;
+                                                // calculate the velocity feedforward
+                                                let mut velocity_feedforward = [0.0; config::N_AXIS];
+                                                //vel = (target - old_target)/dt;
+                                                velocity_feedforward
+                                                    .iter_mut()
+                                                    .zip(target.iter().zip(old_target.iter()))
+                                                    .for_each(|(v, (t, o))| {
+                                                        *v = (*t - *o) / dt as f32;
+                                                    });
+                                                // write the velocity feedforward to the memory
+                                                {
+                                                    SHARED_MEMORY
+                                                        .lock()
+                                                        .await
+                                                        .set_velocity_feedforward(velocity_feedforward);
+                                                }
+                                            }
+                                            None => {
+                                                // if there is no timestamp, set the velocity feedforward to zero
+                                                // ex. first time setting the target position
+                                                {
+                                                    SHARED_MEMORY
+                                                        .lock()
+                                                        .await
+                                                        .set_velocity_feedforward([0.0; config::N_AXIS]);
+                                                }
+                                            }
+                                        }
+                                        // set the new target position - after the feedforward not to modify the target_set_timestamp
+                                        {
+                                            SHARED_MEMORY.lock().await.set_target_position(target);
+                                        }
+
+                                        //return the full state
+                                        let value = { SHARED_MEMORY.lock().await.get_current_position() };
+                                        // let value = { SHARED_MEMORY.lock().await.get_full_state() };
+                                        let value = conversion::float_to_bytes(value);
+                                        let sp = StatusPacket::with_value(id, dxl_error, value);
+                                        trace!("Sending status packet: {:?} {:#x}", sp, sp.to_bytes());
+                                        if let Some(e) = dxl.write(&sp).await.err() {
+                                            error!("Error: {:?}", e);
+                                        }
+
+                                    }
+                                    Err(e) => {
+                                        error!("Error: {:?}", e);
+                                    }
+                                }
+                               
                             }
                             _ => {}
                         }

--- a/src/dynamixel/task.rs
+++ b/src/dynamixel/task.rs
@@ -599,7 +599,8 @@ pub async fn messsage_handler(usart: config::DynamixelUart, dir_pin: AnyPin) {
 
                                         // get the timestamp of the last target set 
                                         // in order to calculate the velocity feedforward
-                                        match { SHARED_MEMORY.lock().await.get_target_set_timestamp() } {
+                                        let timestamp = { SHARED_MEMORY.lock().await.get_target_set_timestamp() } ;
+                                        match timestamp {
                                             Some(target_set_timestamp) => {
                                                 // calculate the time elapsed from the last target set
                                                 let dt = target_set_timestamp.elapsed().as_micros() as f32

--- a/src/dynamixel/usart_io.rs
+++ b/src/dynamixel/usart_io.rs
@@ -1,9 +1,10 @@
-use defmt::{debug, trace, Format};
+use defmt::{debug, error, trace, Format};
 use embassy_stm32::{
     gpio::{AnyPin, Level, Output, Speed},
     usart::{BasicInstance, Uart},
 };
 use embassy_time::{Duration, Timer};
+use embedded_io_async::Write;
 
 use super::packet::{InstructionPacketKind, ParsingError, StatusPacket};
 
@@ -76,7 +77,10 @@ where
 
             total += n;
 
-            assert!(total <= MAX_BUFFER_LENGTH - MAX_READ_BUFFER_LENGTH);
+            if total > (MAX_BUFFER_LENGTH - MAX_READ_BUFFER_LENGTH) {
+                error!("Usart buffer overflow");
+                return Err(CommunicationError::UartError(embassy_stm32::usart::Error::BufferTooLong));
+            }
 
             if n == 0 {
                 continue;


### PR DESCRIPTION
removing the panic behavior for dynamixel usart communication
1) for buffer overflow
2) for wrong number of bytes receved on write

WRONG NUMBER OF BYTES RECEIVED ON WRITE WILL RESULT IN A TIMEOUT!