### PR TITLE
Feat finetuning foc parameters

### DIFF
--- a/src/config/motor.rs
+++ b/src/config/motor.rs
@@ -1,4 +1,6 @@
 use crate::motor_control::Pid;
+use crate::motor_control::ventouse::conversion::rads_to_rpm;
+use crate::config::current_sense::CurrentSensing;
 
 pub struct BrushlessMotor {
     // number of pole pairs
@@ -10,8 +12,8 @@ pub struct BrushlessMotor {
     pid_torque: Pid,
     pid_velocity: Pid,
     pid_position: Pid,
-    pid_torque_flux_limit_max: u32,
-    pid_velocity_limit_max: u32,
+    torque_flux_limit_max: u32,  // milliAmps
+    velocity_limit_max: u32,   // rad/s at the output of the gearbox/axis/motor - depends on the features enabled
     // The encoder PPR value - register ABN_DECODER_PPR
     abn_decoder_ppr: u32,
     // ratio of motor's gearbox
@@ -33,9 +35,9 @@ impl BrushlessMotor {
             pid_flux: Pid { p: 200, i: 500 },
             pid_torque: Pid { p: 200, i: 500 },
             pid_velocity: Pid { p: 500, i: 100 },
-            pid_position: Pid { p: 150, i: 0 },
-            pid_torque_flux_limit_max: 0x00000b82,
-            pid_velocity_limit_max: 0x0000_7D00,
+            pid_position: Pid { p: 100, i: 0 },
+            torque_flux_limit_max: 4000, // 4 amps
+            velocity_limit_max: 40, // 40 rad/s
             // gearing ratios
             gearbox_ratio: 1.0 / 35.0,
             axis_ratio: 12.0 / 64.0,
@@ -54,8 +56,8 @@ impl BrushlessMotor {
             pid_torque: Pid { p: 44, i: 120 },
             pid_velocity: Pid { p: 600, i: 400 },
             pid_position: Pid { p: 50, i: 0 },
-            pid_torque_flux_limit_max: 0x00000b82,
-            pid_velocity_limit_max: 0x0000_7D00,
+            torque_flux_limit_max: 4000, // 4 amps
+            velocity_limit_max: 10, // 10 rad/s
             // gearing ratios
             gearbox_ratio: 1.0 / 25.01,
             axis_ratio: 28.0 / 52.0,
@@ -76,8 +78,8 @@ impl BrushlessMotor {
             pid_velocity: Pid { p: 500, i: 600 },
             pid_position: Pid { p: 50, i: 0 },
 
-            pid_torque_flux_limit_max: 0x00000b82,
-            pid_velocity_limit_max: 0x0000_7D00,
+            torque_flux_limit_max: 4000, // 4 amps
+            velocity_limit_max: 10, // 410 rad/s
             // gearing ratios
             gearbox_ratio: 1.0 / 35.0,
             axis_ratio: 20.0 / 38.0,
@@ -104,11 +106,11 @@ impl BrushlessMotor {
         self.pid_to_reg(self.pid_velocity)
     }
 
-    pub fn pid_torque_flux_limit_max(&self) -> u32 {
-        self.pid_torque_flux_limit_max
+    pub fn torque_flux_limit_max(&self) -> u32 {
+        self.torque_flux_limit_max
     }
-    pub fn pid_velocity_limit_max(&self) -> u32 {
-        self.pid_velocity_limit_max
+    pub fn velocity_limit_max(&self) -> u32 {
+        self.velocity_limit_max 
     }
 
     pub fn gearbox_ratio(&self) -> f32 {

--- a/src/config/motor.rs
+++ b/src/config/motor.rs
@@ -1,6 +1,4 @@
 use crate::motor_control::Pid;
-use crate::motor_control::ventouse::conversion::rads_to_rpm;
-use crate::config::current_sense::CurrentSensing;
 
 pub struct BrushlessMotor {
     // number of pole pairs

--- a/src/motor_control/foc.rs
+++ b/src/motor_control/foc.rs
@@ -12,6 +12,8 @@ use crate::motor_control::motors_io::IOError;
 
 use crate::config;
 
+use super::ventouse::conversion;
+
 // PWM configuration
 const PWM_POLARITIES: u32 = 0x00000000;
 // const PWM_MAXCNT: u32 = 0x00000F9F; // PWM-freq 3999 = > 25KHz
@@ -59,6 +61,8 @@ const PID_VELOCITY_LIMIT: u32 = 0x0000_7D00; //32000 //tuned ok at 500Hz
 pub const OPENLOOP_ACCELERATION: u32 = 0x0000003c; // Wizard default
                                                    // pub const UQ_UD_EXT: u32 = 0x000007D0; // Openloop "torque_target" 2000
 pub const UQ_UD_EXT: u32 = 0x000001000; // Openloop "torque_target" 2000
+// max is 32000
+pub const UQ_UD_LIMIT: u32 = 31000;
 
 #[allow(non_camel_case_types)]
 #[allow(dead_code)]
@@ -682,11 +686,20 @@ where
             ABN_DECODER_PHI_E_PHI_M_OFFSET,
         )?;
 
+        // set uq and ud limits
+        self.tmc4671_checked_write(
+            Tmc4671Registers::PIDOUT_UQ_UD_LIMITS as u8,
+            UQ_UD_LIMIT,
+        )?;
+
         // Limits
         //        self.tmc4671_checked_write(Tmc4671Registers::PID_TORQUE_FLUX_LIMITS as u8, 0x00007D00)?; // 32000
         self.tmc4671_checked_write(
             Tmc4671Registers::PID_TORQUE_FLUX_LIMITS as u8,
-            self.brushless_motor_config.pid_torque_flux_limit_max(),
+            self.current_sensing_config.mAmps_to_adc(
+                self.brushless_motor_config.torque_flux_limit_max() as f32,
+                self.adc_resolution,
+            ) as u32,
         )?;
 
         // PI settings
@@ -710,7 +723,10 @@ where
         //Limite the vel
         self.tmc4671_checked_write(
             Tmc4671Registers::PID_VELOCITY_LIMIT as u8,
-            self.brushless_motor_config.pid_velocity_limit_max(),
+            self.brushless_motor_config
+                .angle_mech_to_elec(conversion::rads_to_rpm(
+                    self.brushless_motor_config.velocity_limit_max() as f32,
+                )) as u32,
         )?;
 
         // calibrate the adc for temperature and dc bus voltage sensing

--- a/src/motor_control/ventouse.rs
+++ b/src/motor_control/ventouse.rs
@@ -622,19 +622,11 @@ where
 
     //////////////////////
     fn get_torque_flux_limit_max(&mut self) -> Result<[f32; 1], IOError> {
-        Ok([self.foc.current_sensing_config.adc_to_mAmps(
-            self.foc.brushless_motor_config.pid_torque_flux_limit_max() as f32,
-            self.foc.adc_resolution,
-        )])
+        Ok([self.foc.brushless_motor_config.torque_flux_limit_max() as f32])
     }
 
     fn get_velocity_limit_max(&mut self) -> Result<[f32; 1], IOError> {
-        Ok([self
-            .foc
-            .brushless_motor_config
-            .angle_elec_to_mech(conversion::rpm_to_rads(
-                self.foc.brushless_motor_config.pid_velocity_limit_max() as f32,
-            ))])
+        Ok([self.foc.brushless_motor_config.velocity_limit_max() as f32])
     }
     /*
     /// Get the absolute uq_ud limit of the motors
@@ -1500,7 +1492,7 @@ impl<'d> RawMotorsIO<1> for VentouseKind<'d> {
     }
 }
 
-mod conversion {
+pub mod conversion {
     // functions to convert encoder values to radians and vice versa
     pub fn encoder_to_rad(enc: i32, ppr: f32) -> f32 {
         enc as f32 / ppr * 6.28318530718 // 2*pi = 6.28


### PR DESCRIPTION
Changed:
- Motor maximal velocity and torque are in miliApms and rad/s 
- Updated the maximal uq and ud duty cycle (set to 31000 - max 32000)
- Updated the values of the max velocity for orbita2d and 3d 
  - 2d => 10 rad/s
  - 3d => 40 rad/s
- for now both torque limits set to 4Amps
 