### PR TITLE
feat torque feedforward in position control mode

### DIFF
--- a/src/motor_control/actuator.rs
+++ b/src/motor_control/actuator.rs
@@ -704,6 +704,24 @@ impl<'d, const N: usize> RawMotorsIO<N> for Actuator<'d, N> {
         Ok(())
     }
 
+    // torque feedforward
+    fn set_torque_feedforward(&mut self, torque: [f32; N]) -> Result<()> {
+        for (i, axis) in self.axes.iter_mut().enumerate() {
+            axis.set_torque_feedforward([self.inverted * torque[i]])?;
+        }
+
+        Ok(())
+    }
+    // get torque feedforward
+    fn get_torque_feedforward(&mut self) -> Result<[f32; N]> {
+        let mut res = [0.0; N];
+        for (i, axis) in self.axes.iter_mut().enumerate() {
+            res[i] = self.inverted * axis.get_torque_feedforward()?[0];
+        }
+
+        Ok(res)
+    }
+
     // Set velocity feedforward
     fn set_velocity_feedforward(&mut self, velocity: [f32; N]) -> Result<()> {
         for (i, axis) in self.axes.iter_mut().enumerate() {

--- a/src/motor_control/foc.rs
+++ b/src/motor_control/foc.rs
@@ -648,6 +648,28 @@ where
         self.tmc4671_get_lower_i16(Tmc4671Registers::PID_TORQUE_FLUX_TARGET as u8)
     }
 
+
+
+    pub fn tmc4671_set_torque_offset(
+        &mut self,
+        torque_offset: i16,
+    ) -> Result<u32, embassy_stm32::spi::Error> {
+        // read current state first -> bits 15-0 is flux_target and should be kept.
+        let mut torque_and_flux =
+            self.tmc4671_read_register(Tmc4671Registers::PID_TORQUE_FLUX_OFFSET as u8)?;
+        torque_and_flux &= 0x0000FFFFu32; // clear actual torque
+        torque_and_flux |= (torque_offset as u32) << 16;
+        self.tmc4671_write_register(
+            Tmc4671Registers::PID_TORQUE_FLUX_OFFSET as u8,
+            torque_and_flux,
+        )
+    }
+    pub fn tmc4671_get_torque_offset(&mut self) -> Result<i32, embassy_stm32::spi::Error> {
+        let mut torque_and_flux = self.tmc4671_read_register(Tmc4671Registers::PID_TORQUE_FLUX_OFFSET as u8)?;
+        Ok((torque_and_flux >> 16) as i32)
+    }
+
+
     pub fn tmc4671_set_torque_target(
         &mut self,
         torque_target: i16,

--- a/src/motor_control/motors_io.rs
+++ b/src/motor_control/motors_io.rs
@@ -42,6 +42,10 @@ pub trait RawMotorsIO<const N: usize> {
     // Set the velocity feedforward of the motors (in radians per second)
     fn set_velocity_feedforward(&mut self, velocity: [f32; N]) -> Result<()>;
     fn get_velocity_feedforward(&mut self) -> Result<[f32; N]>;
+ 
+    // set torque feedforward of the motors 
+    fn set_torque_feedforward(&mut self, torque: [f32; N]) -> Result<()>;
+    fn get_torque_feedforward(&mut self) -> Result<[f32; N]>;
 
     fn get_board_temperature(&mut self) -> Result<[f32; N]>;
     fn get_bus_voltage(&mut self) -> Result<[f32; N]>;

--- a/src/motor_control/task.rs
+++ b/src/motor_control/task.rs
@@ -922,9 +922,7 @@ pub async fn control_loop(mut config: ActuatorConfig) {
     let mut init_target_position = { SHARED_MEMORY.lock().await.get_target_position() };
 
     // a variable used for the safe fault handling
-    let emergency_stop_torque_limits = [0.75, 0.5, 0.3, 0.1, 0.05];
-    let emergency_stop_time_per_torque_secs = 1.75; // seconds
-    let emergency_stop_response_counter_max = emergency_stop_torque_limits.len()*((emergency_stop_time_per_torque_secs*1000.0) as usize); // 3secs per torque limit (1000 loops at 1kHz)
+    let emergency_stop_response_counter_max: usize = 7000; // 7secs (1000 loops at 1kHz)
     let mut quick_stop_response_counter  = 0;
     let mut fault_response_counter = 0; 
 
@@ -1105,9 +1103,11 @@ pub async fn control_loop(mut config: ActuatorConfig) {
 
                 // if velocity is almost zero and the torque is almost zero, stop the operation
                 // dont stop if the fault response counter is not yet at the maximum
+                // and stop right away if the fault response counter is at the two times the maximum (emergency stop)
                 if (velocity.iter().all(|v| v.abs() < 0.05)) && 
                     (torque.iter().all(|t| t.abs() < 100.0) && 
-                    (quick_stop_response_counter >= emergency_stop_response_counter_max)){
+                    (quick_stop_response_counter >= emergency_stop_response_counter_max)) ||
+                    quick_stop_response_counter >= 2*emergency_stop_response_counter_max {
                     torque_on = [false; config::N_AXIS];
                     {
                         SHARED_MEMORY.lock().await.set_torque_on(torque_on)
@@ -1230,6 +1230,13 @@ pub async fn control_loop(mut config: ActuatorConfig) {
                 // set the target position (filtered or not)
                 actuator.set_target_position(target).unwrap_or_else(|e| {
                     error!("Error setting target pos: {:?}", e);
+                    loop_communication_error = true;
+                });
+
+                
+                let torque_ff = { SHARED_MEMORY.lock().await.get_target_torque() };
+                actuator.set_torque_feedforward(torque_ff).unwrap_or_else(|e| {
+                    error!("Error setting torque feedforward: {:?}", e);
                     loop_communication_error = true;
                 });
             }

--- a/src/motor_control/ventouse.rs
+++ b/src/motor_control/ventouse.rs
@@ -513,6 +513,31 @@ where
             .map_err(IOError::SpiError)
     }
 
+    /// Set the torque feedforward
+    fn set_torque_feedforward(&mut self, torque: [f32; 1]) -> Result<()> {
+        // torque from mAmps to ADC counts
+        let torque_adc = self
+            .foc
+            .current_sensing_config
+            .mAmps_to_adc(torque[0], self.foc.adc_resolution);
+        self.foc
+            .tmc4671_set_torque_offset(torque_adc as i16)
+            .map(|_| ())
+            .map_err(IOError::SpiError)
+    }
+
+    fn get_torque_feedforward(&mut self) -> Result<[f32; 1]> {
+        let torque_adc = self
+            .foc
+            .tmc4671_get_torque_offset()
+            .map_err(IOError::SpiError)?;
+        let torque = self
+            .foc
+            .current_sensing_config
+            .adc_to_mAmps(torque_adc as f32, self.foc.adc_resolution);
+        Ok([torque])
+    }
+
     /// Set the current velocity feedforward (in radians per second)
     fn set_velocity_feedforward(&mut self, velocity: [f32; 1]) -> Result<()> {
         let vel_rpm = self
@@ -1254,6 +1279,23 @@ impl<'d> RawMotorsIO<1> for VentouseKind<'d> {
             VentouseKind::A(va) => va.get_velocity_feedforward(),
             VentouseKind::B(vb) => vb.get_velocity_feedforward(),
             VentouseKind::C(vc) => vc.get_velocity_feedforward(),
+        }
+    }
+
+    // Set torque feedforward
+    fn set_torque_feedforward(&mut self, torque: [f32; 1]) -> Result<()> {
+        match self {
+            VentouseKind::A(va) => va.set_torque_feedforward(torque),
+            VentouseKind::B(vb) => vb.set_torque_feedforward(torque),
+            VentouseKind::C(vc) => vc.set_torque_feedforward(torque),
+        }
+    }
+    // get torque feedforward
+    fn get_torque_feedforward(&mut self) -> Result<[f32; 1]> {
+        match self {
+            VentouseKind::A(va) => va.get_torque_feedforward(),
+            VentouseKind::B(vb) => vb.get_torque_feedforward(),
+            VentouseKind::C(vc) => vc.get_torque_feedforward(),
         }
     }
 


### PR DESCRIPTION
This PR adds the torque feedforward possibility for position control. 

The torque feedforward isreceived from the ethercat network from the target_torque message while in position control mode.

